### PR TITLE
Some typo's and href updates; fixes #50

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -374,6 +374,10 @@ a.msdn-link {
 	/* TODO: somehow style MSDN links */
 }
 
+a.wikipedia-link {
+	/* TODO: somehow style wikipedia links */
+}
+
 .story-intro, .story-outro {
 	font-style: italic;
 	margin-bottom: 1em;

--- a/index.html
+++ b/index.html
@@ -1,183 +1,184 @@
 <!DOCTYPE html>
 <html>
-	<head>
-		<meta charset="utf-8">
-		<!--<link href='https://fonts.googleapis.com/css?family=Amatic+SC' rel='stylesheet' type='text/css'>-->
-		<link href='https://fonts.googleapis.com/css?family=Cabin' rel='stylesheet' type='text/css'>
-		<link rel="stylesheet" href="css/bootstrap.min.css">
-		<link rel="stylesheet" href="css/bootstrap-theme.min.css">
-		<link rel="stylesheet" href="css/introjs.css">
-		<link rel='icon' href='img/favicon.png'>
-<!--		<link rel="stylesheet" href="css/bootstrap-solarized-dark.css">
+  <head>
+    <meta charset="utf-8">
+    <!--<link href='https://fonts.googleapis.com/css?family=Amatic+SC' rel='stylesheet' type='text/css'>-->
+    <link href='https://fonts.googleapis.com/css?family=Cabin' rel='stylesheet' type='text/css'>
+    <link rel="stylesheet" href="css/bootstrap.min.css">
+    <link rel="stylesheet" href="css/bootstrap-theme.min.css">
+    <link rel="stylesheet" href="css/introjs.css">
+    <link rel='icon' href='img/favicon.png'>
+<!--    <link rel="stylesheet" href="css/bootstrap-solarized-dark.css">
 -->
-		<link rel="stylesheet" href="css/main.css">
-		<title>The Deadlock Empire</title>
+    <link rel="stylesheet" href="css/main.css">
+    <title>The Deadlock Empire</title>
 
-		<script src="js/3rdparty/jquery.js"></script>
-		<script src="js/3rdparty/bootstrap.min.js"></script>
-		<script src="js/3rdparty/bootbox.min.js"></script>
-		<script src="js/3rdparty/intro.js"></script>
-		<script src="js/3rdparty/mousetrap.min.js"></script>
+    <script src="js/3rdparty/jquery.js"></script>
+    <script src="js/3rdparty/bootstrap.min.js"></script>
+    <script src="js/3rdparty/bootbox.min.js"></script>
+    <script src="js/3rdparty/intro.js"></script>
+    <script src="js/3rdparty/mousetrap.min.js"></script>
 
-		<script src="js/game_state.js"></script>
-		<script src="js/ui.js"></script>
-		<script src="js/win.js"></script>
-		<script src="js/common.js"></script>
-		<script src="js/expression.js"></script>
-		<script src="js/variables.js"></script>
-		<script src="js/instructions/instructions.js"></script>
-		<script src="js/instructions/instructions-synchronization.js"></script>
-		<script src="js/instructions/instructions-high-level-synchronization.js"></script>
-		<script src="js/instructions/instructions-queue.js"></script>
-		<script src="js/level.js"></script>
-		<script src="js/thread.js">s</script>
-		<script src="js/main.js"></script>
-		<script src="js/menu.js"></script>
+    <script src="js/game_state.js"></script>
+    <script src="js/ui.js"></script>
+    <script src="js/win.js"></script>
+    <script src="js/common.js"></script>
+    <script src="js/language.js"></script>
+    <script src="js/expression.js"></script>
+    <script src="js/variables.js"></script>
+    <script src="js/instructions/instructions.js"></script>
+    <script src="js/instructions/instructions-synchronization.js"></script>
+    <script src="js/instructions/instructions-high-level-synchronization.js"></script>
+    <script src="js/instructions/instructions-queue.js"></script>
+    <script src="js/level.js"></script>
+    <script src="js/thread.js">s</script>
+    <script src="js/main.js"></script>
+    <script src="js/menu.js"></script>
 
-		<script src="js/content/levels.js"></script>
-		<script src="js/content/dragons.js"></script>
-		<script src="js/content/tutorial.js"></script>
-		<script src="js/content/levels-high-level-primitives.js"></script>
-		<script src="js/content/campaign.js"></script>
+    <script src="js/content/levels.js"></script>
+    <script src="js/content/dragons.js"></script>
+    <script src="js/content/tutorial.js"></script>
+    <script src="js/content/levels-high-level-primitives.js"></script>
+    <script src="js/content/campaign.js"></script>
 
-		<!--
-			Google Analytics.
+    <!--
+      Google Analytics.
 
-			We are deeply sorry if you are offended by our
-			collection of pageview data. We suggest using tracking
-			protection - for example, modern versions of Firefox
-			can automatically disable any tracking scripts.
-			Thank you for playing The Deadlock Empire and we hope
-			you can forgive us for infringing on your privacy.
+      We are deeply sorry if you are offended by our
+      collection of pageview data. We suggest using tracking
+      protection - for example, modern versions of Firefox
+      can automatically disable any tracking scripts.
+      Thank you for playing The Deadlock Empire and we hope
+      you can forgive us for infringing on your privacy.
 
-			http://hudecekpetr.cz/friend.html
-		-->
-		<script>
-			(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-				(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-			m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-			})(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+      http://hudecekpetr.cz/friend.html
+    -->
+    <script>
+      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+      m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+      })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-			ga('create', 'UA-73203312-1', 'auto');
-			ga('send', 'pageview');
-		</script>
+      ga('create', 'UA-73203312-1', 'auto');
+      ga('send', 'pageview');
+    </script>
 
-		<!-- Open Graph tags to customize Facebook link previews. -->
-		<meta property="og:url" content="https://deadlockempire.github.io">
-		<meta property="og:title" content="The Deadlock Empire">
-		<meta property="og:description" content="Slay dragons, learn
-		concurrency! Play the cunning Scheduler, exploit flawed
-		programs and defeat the armies of the Parallel Wizard.">
-		<meta property="og:image" content="http://deadlockempire.github.io/img/logo-large.png">
+    <!-- Open Graph tags to customize Facebook link previews. -->
+    <meta property="og:url" content="https://deadlockempire.github.io">
+    <meta property="og:title" content="The Deadlock Empire">
+    <meta property="og:description" content="Slay dragons, learn
+    concurrency! Play the cunning Scheduler, exploit flawed
+    programs and defeat the armies of the Parallel Wizard.">
+    <meta property="og:image" content="http://deadlockempire.github.io/img/logo-large.png">
 
-	</head>
-	<body>
-		<!-- Load Facebook SDK for JavaScript -->
-		<div id="fb-root"></div>
-		<script>
-		(function(d, s, id) {
-			var js, fjs = d.getElementsByTagName(s)[0];
-			if (d.getElementById(id)) return;
-			js = d.createElement(s); js.id = id;
-			js.src =
-				"//connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.2&appId=100259203407083";
-			fjs.parentNode.insertBefore(js, fjs);
-		}(document, 'script', 'facebook-jssdk'));
-		</script>
+  </head>
+  <body>
+    <!-- Load Facebook SDK for JavaScript -->
+    <div id="fb-root"></div>
+    <script>
+    (function(d, s, id) {
+      var js, fjs = d.getElementsByTagName(s)[0];
+      if (d.getElementById(id)) return;
+      js = d.createElement(s); js.id = id;
+      js.src =
+        "//connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.2&appId=100259203407083";
+      fjs.parentNode.insertBefore(js, fjs);
+    }(document, 'script', 'facebook-jssdk'));
+    </script>
 
-		<div  id="mainContainer">
-		<div class="container">
-			<div id="game-window">
-			<div id="debug-toolbar" style="border: 1px solid black; width: 100%; margin: 2px; padding: 2px;">
-				This is the toolbar. | Select level:
-				<select id="levelSelect" >
-				</select>
-				<button class="btn btn-default" id="start">Start</button>
-				|
-				<button class="btn btn-default" id="goToMain">Go To Main Menu</button>
-				|
-				<button class="btn btn-default" id="clearProgress">Clear Saved Progress</button>
-			</div>
-			<div id="mainarea">
-			</div>
-			<div id="alert" style="display: none; border: 1px solid black;">
-				<button class="btn btn-default" id="alertHide">[Hide]</button>
-				<span id="alertCaption" style="font-weight: bold;">Title</span><br>
-				<span id="alertText">This is the alert message.</span>
-			</div>
-			<footer>
-				<span class="fb-share-button"
-					data-href="https://deadlockempire.github.io"
-					data-layout="button_count">
-				</span>
+    <div  id="mainContainer">
+    <div class="container">
+      <div id="game-window">
+      <div id="debug-toolbar" style="border: 1px solid black; width: 100%; margin: 2px; padding: 2px;">
+        This is the toolbar. | Select level:
+        <select id="levelSelect" >
+        </select>
+        <button class="btn btn-default" id="start">Start</button>
+        |
+        <button class="btn btn-default" id="goToMain">Go To Main Menu</button>
+        |
+        <button class="btn btn-default" id="clearProgress">Clear Saved Progress</button>
+      </div>
+      <div id="mainarea">
+      </div>
+      <div id="alert" style="display: none; border: 1px solid black;">
+        <button class="btn btn-default" id="alertHide">[Hide]</button>
+        <span id="alertCaption" style="font-weight: bold;">Title</span><br>
+        <span id="alertText">This is the alert message.</span>
+      </div>
+      <footer>
+        <span class="fb-share-button"
+          data-href="https://deadlockempire.github.io"
+          data-layout="button_count">
+        </span>
 
-				<span id="credits">
-					Got any ideas or feedback? Both are much
-					appreciated at <a href="http://goo.gl/forms/i05ukNUMmB">this form</a>.<br>
-					GitHub: <a href="https://github.com/deadlockempire/deadlockempire.github.io">deadlockempire/deadlockempire.github.io</a>.
-					Made by <a href="http://hudecekpetr.cz">Petr Hudeček</a>
-					and <a href="http://rny.cz">Michal Pokorný</a> at
-					HackCambridge 2016.
-				</span>
-			</footer>
-			</div>
+        <span id="credits">
+          Got any ideas or feedback? Both are much
+          appreciated at <a href="http://goo.gl/forms/i05ukNUMmB">this form</a>.<br>
+          GitHub: <a href="https://github.com/deadlockempire/deadlockempire.github.io">deadlockempire/deadlockempire.github.io</a>.
+          Made by <a href="http://hudecekpetr.cz">Petr Hudeček</a>
+          and <a href="http://rny.cz">Michal Pokorný</a> at
+          HackCambridge 2016.
+        </span>
+      </footer>
+      </div>
 
-		</div>
+    </div>
 
-		<div id="win-screen">
-			<div class="container">
-				<div class="top-section">
-					<span class="icon glyphicon glyphicon-ok"></span>
+    <div id="win-screen">
+      <div class="container">
+        <div class="top-section">
+          <span class="icon glyphicon glyphicon-ok"></span>
 
-					<h3>
-						<span id="win-congratulation">
-						You win!
-						</span>
-					</h3>
+          <h3>
+            <span id="win-congratulation">
+            You win!
+            </span>
+          </h3>
 
-					<div class="victory-condition">
-					</div>
-				</div>
+          <div class="victory-condition">
+          </div>
+        </div>
 
-				<div class="win-part">
-					<div id="win-message"></div>
-				</div>
+        <div class="win-part">
+          <div id="win-message"></div>
+        </div>
 
-				<div class="buttons">
-					<button id="dismiss-win" class="btn btn-default">Back to the code</button>
-					<button id="win-go-to-menu" class="btn btn-default">Return to Main Menu</button>
-					<button id="win-next-level" class="btn btn-primary">Next challenge&nbsp;
-						<span class="glyphicon glyphicon-chevron-right"></span></button>
-				</div>
-			</div>
-		</div>
+        <div class="buttons">
+          <button id="dismiss-win" class="btn btn-default">Back to the code</button>
+          <button id="win-go-to-menu" class="btn btn-default">Return to Main Menu</button>
+          <button id="win-next-level" class="btn btn-primary">Next challenge&nbsp;
+            <span class="glyphicon glyphicon-chevron-right"></span></button>
+        </div>
+      </div>
+    </div>
 
-		<div id="lose-screen">
-			<div class="container">
-				<div class="top-section">
-					<span class="icon glyphicon glyphicon-remove"></span>
+    <div id="lose-screen">
+      <div class="container">
+        <div class="top-section">
+          <span class="icon glyphicon glyphicon-remove"></span>
 
-					<h3>
-						<span id="fail-heading">
-						Challenge lost!
-						</span>
-					</h3>
-				</div>
+          <h3>
+            <span id="fail-heading">
+            Challenge lost!
+            </span>
+          </h3>
+        </div>
 
-				<div class="lose-part">
-					<div id="lose-message"></div>
+        <div class="lose-part">
+          <div id="lose-message"></div>
 
-					<div class="failure-condition">
-					</div>
-				</div>
+          <div class="failure-condition">
+          </div>
+        </div>
 
-				<div class="buttons">
-					<button id="lose-restart" class="btn btn-primary">Reset and try again</button>
-					<button id="lose-step-back" class="btn btn-default">Return to code and undo last step</button>
-					<button id="lose-go-to-menu" class="btn btn-default">Return to Main Menu</button>
-				</div>
-			</div>
-		</div>		</div>
+        <div class="buttons">
+          <button id="lose-restart" class="btn btn-primary">Reset and try again</button>
+          <button id="lose-step-back" class="btn btn-default">Return to code and undo last step</button>
+          <button id="lose-go-to-menu" class="btn btn-default">Return to Main Menu</button>
+        </div>
+      </div>
+    </div>    </div>
 
-	</body>
+  </body>
 </html>

--- a/js/common.js
+++ b/js/common.js
@@ -5,46 +5,50 @@
 var debugMode = false;
 
 var getQueryString = function ( field, url ) {
-	var href = url ? url : window.location.href;
-	var reg = new RegExp( '[?&]' + field + '=([^&#]*)', 'i' );
-	var string = reg.exec(href);
-	return string ? string[1] : null;
+    var href = url ? url : window.location.href;
+    var reg = new RegExp( '[?&]' + field + '=([^&#]*)', 'i' );
+    var string = reg.exec(href);
+    return string ? string[1] : null;
 };
 
 $(function() {
-	debugMode = (getQueryString('debug') != null);
-	if (!debugMode) {
-		$('#debug-toolbar').remove();
-	}
+    debugMode = (getQueryString('debug') != null);
+    if (!debugMode) {
+        $('#debug-toolbar').remove();
+    }
 });
 
 /**
  * Called when something that shouldn't happen happens, like level errors.
  */
 var fail = function() {
-	console.warn.apply(console, arguments);
-	if (debugMode) {
-		alert("FAIL");
-	}
+    console.warn.apply(console, arguments);
+    if (debugMode) {
+        alert("FAIL");
+    }
 };
 
 // We can leave this in the open. No disadvantage and more usable for me.
 Mousetrap.bind('shift+w', function() {
-	win("You have used the Shift+W debugging keyboard shortcut to win.");
+    win("You have used the Shift+W debugging keyboard shortcut to win.");
 });
 Mousetrap.bind(['u', 'up'], function() {
-	if (undoHistory.length > 0) {
-		undo();
-	}
+    if (undoHistory.length > 0) {
+        undo();
+    }
 });
 
 var sendEvent = function(category, action, label) {
-	if (ga) {
-		ga('send', {
-			hitType: 'event',
-			eventCategory: category,
-			eventAction: action,
-			eventLabel: label
-		});
-	}
+    if (ga) {
+        ga('send', {
+            hitType: 'event',
+            eventCategory: category,
+            eventAction: action,
+            eventLabel: label
+        });
+    }
+};
+
+var spanTag = function(span, content) {
+    return "<span class='" + span + "'>" + content + "</span>";
 };

--- a/js/content/dragons.js
+++ b/js/content/dragons.js
@@ -94,7 +94,7 @@ levels["D2-Sorcerer"] = new Level(
     ],
     {
         "conduit": new ObjectVariable("conduit"),
-        "energyBursts": new QueueVariable("energyBursts", "EnergyBurst", 3)
+        "energyBursts": new QueueVariable("energyBursts", new ObjectType("EnergyBurst"), 3)
     }
 );
 levels["D4-Boss"] = new Level(

--- a/js/content/dragons.js
+++ b/js/content/dragons.js
@@ -69,7 +69,7 @@ levels["D2-Sorcerer"] = new Level(
             new MonitorEnterInstruction("conduit"),
             new CommentInstruction("I summon mana for you, dragon!"),
             new CommentInstruction("Incinerate the enemies!"),
-            createEnqueueUnsafe("energyBursts", "new EnergyBurst()"),
+            createEnqueueUnsafe("energyBursts", LanguageDependentConstruction("EnergyBurst")),
             new MonitorExitInstruction("conduit"),
             createOuterWhileEnd()
         ], "Sorcerer"), new Thread([

--- a/js/content/levels-high-level-primitives.js
+++ b/js/content/levels-high-level-primitives.js
@@ -32,9 +32,9 @@ levels["H1-ManualResetEvent"] = new Level(
     }
 );
 levels["H2-CountdownEvent"] = new Level(
-  "H2-CountdownEvent",
-  "Countdown Event",
-  "Introduces the CountdownEvent class, a more powerful barrier but also trickier.",
+    "H2-CountdownEvent",
+    "Countdown Event",
+    "Introduces the CountdownEvent class, a more powerful barrier but also trickier.",
     "<div class='story-intro'>The Countdown Dragons are a threat to us - this newest Empire weapon flies right up to you and self-destructs at the worst possible moment, sending ripples of doom throughout our armies.</div>" +
     "The <b><a href='https://msdn.microsoft.com/en-us/library/system.threading.countdownevent'>CountdownEvent</a></b> class has an internal counter and is initialized with a number. " +
     "Its <a href='https://msdn.microsoft.com/en-us/library/dd321954'>.Signal()</a> method atomically decrements the counter. Its <a href='https://msdn.microsoft.com/en-us/library/dd270769'>.Wait()</a> method blocks the calling thread until the counter reaches zero. You can use this primitive to wait until all threads finished their work if you know the size of the work, for example. Its advantage compared to the <a href='https://msdn.microsoft.com/en-us/library/system.threading.barrier'>Barrier</a> is that you can wait without signalling, and that you can signal multiple times from the same thread.<br><br>" +

--- a/js/content/levels.js
+++ b/js/content/levels.js
@@ -90,11 +90,7 @@ var levels = {
             ], "Three-Headed Dragon")
         ],
         {
-            "counter": {
-                name: "counter",
-                type: "System.Int32",
-                value : 0
-            }
+            "counter": new IntegerVariable("counter", 0)
         }
     ),
     "4-confusedCounter" : new Level(
@@ -121,16 +117,8 @@ var levels = {
             ])
         ],
         {
-            "first": {
-                name: "first",
-                type: "System.Int32",
-                value : 0
-            },
-            "second": {
-                name: "second",
-                type: "System.Int32",
-                value : 0
-            }
+            "first": new IntegerVariable("first", 0),
+            "second": new IntegerVariable("second", 0)
         }
     ),
     "5-peterson": new Level(
@@ -400,7 +388,7 @@ var levels = {
         ,
         {
             "ss" : new ManualResetEventVariable("ss", 0),
-            "queue" : new QueueVariable("queue", "Dragon", 0)
+            "queue" : new QueueVariable("queue", new ObjectType("Dragon"), 0)
         }
     ),
     "S3-producerConsumer" : new Level(
@@ -425,7 +413,7 @@ var levels = {
             ], "The Consumer")
         ],
         {
-            "queue" : new QueueVariable("queue", "Golem", 0)
+            "queue" : new QueueVariable("queue", new ObjectType("Golem"), 0)
         }
     ),
     "CV1-simple": new Level(
@@ -466,7 +454,7 @@ var levels = {
         ],
         {
             "mutex" : new ObjectVariable("mutex", "unimportant"),
-            "queue" : new QueueVariable("queue", "int", 0)
+            "queue" : new QueueVariable("queue", new IntegerType(), 0)
         }
     )
 };

--- a/js/content/levels.js
+++ b/js/content/levels.js
@@ -17,11 +17,7 @@ var levels = {
             ])
         ],
         {
-            "a" : {
-                name : "a",
-                type : "System.Int32",
-                value : 0
-            }
+            "a" : new IntegerVariable("a", 0)
         }
     ),
     "2-flags": new Level(
@@ -65,11 +61,7 @@ var levels = {
             ], "Second Army")
         ],
         {
-            "flag" : {
-                name : "flag",
-                type : "System.Boolean",
-                value : false
-            }
+            "flag" : new BooleanVariable("flag", false)
         }
     ),
     "3-simpleCounter" : new Level(
@@ -213,26 +205,10 @@ var levels = {
 
         ],
         {
-            "flag1" : {
-                name : "flag1",
-                type : "System.Boolean",
-                value : false
-            },
-            "flag2" : {
-                name : "flag2",
-                type : "System.Boolean",
-                value : false
-            },
-            "flag3" : {
-                name : "flag3",
-                type : "System.Boolean",
-                value : false
-            },
-            turn : {
-                name : "turn",
-                type : "System.Int32",
-                value : 2
-            }
+            "flag1" : new BooleanVariable("flag1", false),
+            "flag2" : new BooleanVariable("flag2", false),
+            "flag3" : new BooleanVariable("flag3", false),
+            "turn" : new IntegerVariable("turn", 2)
         }
     ),
     "L1-lock": new Level(
@@ -274,16 +250,8 @@ var levels = {
         ])
         ],
         {
-            "mutex": {
-                name : "mutex",
-                type : "System.Object",
-                value : "unimportant"
-            },
-            "i": {
-                name : "i",
-                type : "System.Int32",
-                value : 0
-            }
+            "mutex": new ObjectVariable("mutex", "unimportant"),
+            "i": new IntegerVariable("i", 0)
         }
     ),
     "L2-deadlock": new Level(
@@ -310,17 +278,8 @@ var levels = {
             ])
         ],
         {
-            "mutex" : {
-                name : "mutex",
-                type : "System.Object",
-                value : "unimportant"
-            },
-            "mutex2" : {
-                name : "mutex2",
-                type : "System.Object",
-                value : "unimportant"
-            }
-
+            "mutex" : new ObjectVariable("mutex", "unimportant"),
+            "mutex2" : new ObjectVariable("mutex2", "unimportant")
         }
     ),
     "L3-complexer": new Level(
@@ -371,12 +330,8 @@ var levels = {
         {
             "mutex" : new ObjectVariable("mutex"),
             "mutex2" : new ObjectVariable("mutex2"),
-            "mutex3" :  new ObjectVariable("mutex3"),
-            "flag":  {
-                name : "flag",
-                type : "System.Boolean",
-                value : false
-            }
+            "mutex3" : new ObjectVariable("mutex3"),
+            "flag": new BooleanVariable("flag", false)
         }
     ),
     "S1-simple" : new Level(
@@ -444,11 +399,7 @@ var levels = {
         ]
         ,
         {
-            "ss" : {
-                name : "ss",
-                type : "System.Threading.SemaphoreSlim",
-                value : 0
-            },
+            "ss" : new ManualResetEventVariable("ss", 0),
             "queue" : new QueueVariable("queue", "Dragon", 0)
         }
     ),
@@ -514,11 +465,7 @@ var levels = {
             ])
         ],
         {
-            "mutex" : {
-                name : "mutex",
-                type : "System.Object",
-                value : "unimportant"
-            },
+            "mutex" : new ObjectVariable("mutex", "unimportant"),
             "queue" : new QueueVariable("queue", "int", 0)
         }
     )

--- a/js/content/levels.js
+++ b/js/content/levels.js
@@ -1,523 +1,525 @@
 var levels = {
-	"1-simpletest": new Level(
-		"1-simpletest",
-		"Simple Test",
-		"Tutorial. Learn to step through a program in The Deadlock Empire.",
-		"Learn to step through a program in the Thread Safety Breaker in this tutorial level. Simply keep stepping forwards until you reach the failure statement to win.",
-		"The failure statement is like an 'assert false' statement. It represents a point in the program that should never be reached or the program was incorrectly programmed. In this game, reaching a failure statement always results in immediate victory.",
-		[
-			new Thread([
-				createAssignment("a", new LiteralExpression(1)),
-				createAssignment("a",
-					new AdditionExpression(new VariableExpression("a"),
-					new LiteralExpression(2))),
-				new IfInstruction(new EqualityExpression(new VariableExpression("a"), new LiteralExpression(3)), "if"),
-				new FailureInstruction(),
-				new EndIfInstruction("}", "if")
-			])
-		],
-		{
-			"a" : {
-				name : "a",
-				type : "System.Int32",
-				value : 0
-			}
-		}
-	),
-	"2-flags": new Level(
-		"2-flags",
-		"Boolean Flags Are Enough For Everyone",
-		"Or so thinks the Deadlock Empire.",
-		"<div class='story-intro'>The day finally came. The Deadlock Empire opened its gates and from them surged massive amounts of soldiers, loyal servants of the evil Parallel Wizard. The Wizard has many strengths - his armies are fast, and he can do a lot of stuff that we can't. But now he set out to conquer the world, and we cannot have that.<br><br>" +
-		"You are our best <b>Scheduler</b>, commander! We have fewer troops and simpler ones, so we will need your help. Already two armies of the Deadlock Empire are approaching our border keeps. They are poorly equipped and poorly trained, however. You might be able to desync them and break their morale.</div>" +
-		"<div>If two threads enter a critical section at the same time, the program is not thread-safe and thus you win the challenge. The <i>while</i> loop at the beginning is called a <i>guard</i> - it prevents execution from continuing into a critical section under certain conditions. However, this here is a weak guard. After you pass it in one thread, if you stop at the right time, you will be able to pass it in the other thread, too.</div>",
-		"<div class='story-outro'>You've done it, Scheduler! The armies have broken apart and our soldiers are driving them back. But do not grow complacent - this is merely the beginning of a war - <b>The Great Concurrency War</b> - and we <i>will</i>  win it!</div><div>Congratulations!</div>",
-		[
-			new Thread([
-				new WhileInstruction(new LiteralExpression(true), "eternal"),
+    "1-simpletest": new Level(
+        "1-simpletest",
+        "Simple Test",
+        "Tutorial. Learn to step through a program in The Deadlock Empire.",
+        "Learn to step through a program in the Thread Safety Breaker in this tutorial level. Simply keep stepping forwards until you reach the failure statement to win.",
+        "The failure statement is like an 'assert false' statement. It represents a point in the program that should never be reached or the program was incorrectly programmed. In this game, reaching a failure statement always results in immediate victory.",
+        [
+            new Thread([
+                createAssignment("a", new LiteralExpression(1)),
+                createAssignment("a",
+                    new AdditionExpression(new VariableExpression("a"),
+                    new LiteralExpression(2))),
+                new IfInstruction(new EqualityExpression(new VariableExpression("a"), new LiteralExpression(3)), "if"),
+                new FailureInstruction(),
+                new EndIfInstruction("}", "if")
+            ])
+        ],
+        {
+            "a" : {
+                name : "a",
+                type : "System.Int32",
+                value : 0
+            }
+        }
+    ),
+    "2-flags": new Level(
+        "2-flags",
+        "Boolean Flags Are Enough For Everyone",
+        "Or so thinks the Deadlock Empire.",
+        "<div class='story-intro'>The day finally came. The Deadlock Empire opened its gates and from them surged massive amounts of soldiers, loyal servants of the evil Parallel Wizard. The Wizard has many strengths - his armies are fast, and he can do a lot of stuff that we can't. But now he set out to conquer the world, and we cannot have that.<br><br>" +
+        "You are our best <b>Scheduler</b>, commander! We have fewer troops and simpler ones, so we will need your help. Already two armies of the Deadlock Empire are approaching our border keeps. They are poorly equipped and poorly trained, however. You might be able to desync them and break their morale.</div>" +
+        "<div>If two threads enter a critical section at the same time, the program is not thread-safe and thus you win the challenge. The <i>while</i> loop at the beginning is called a <i>guard</i> - it prevents execution from continuing into a critical section under certain conditions. However, this here is a weak guard. After you pass it in one thread, if you stop at the right time, you will be able to pass it in the other thread, too.</div>",
+        "<div class='story-outro'>You've done it, Scheduler! The armies have broken apart and our soldiers are driving them back. But do not grow complacent - this is merely the beginning of a war - <b>The Great Concurrency War</b> - and we <i>will</i>  win it!</div><div>Congratulations!</div>",
+        [
+            new Thread([
+                new WhileInstruction(new LiteralExpression(true), "eternal"),
 
-				new WhileInstruction(new InequalityExpression(new VariableExpression("flag"), new LiteralExpression(false)), "while"),
-				new EmptyStatement(),
-				new EndWhileInstruction("while"),
+                new WhileInstruction(new InequalityExpression(new VariableExpression("flag"), new LiteralExpression(false)), "while"),
+                new EmptyStatement(),
+                new EndWhileInstruction("while"),
 
-				createAssignment("flag", new LiteralExpression(true)),
+                createAssignment("flag", new LiteralExpression(true)),
 
-				new CriticalSectionInstruction(),
+                new CriticalSectionInstruction(),
 
-				createAssignment("flag", new LiteralExpression(false)),
+                createAssignment("flag", new LiteralExpression(false)),
 
-				new EndWhileInstruction("eternal")
-			], "First Army"),
-			new Thread([
-				new WhileInstruction(new LiteralExpression(true), "eternal"),
+                new EndWhileInstruction("eternal")
+            ], "First Army"),
+            new Thread([
+                new WhileInstruction(new LiteralExpression(true), "eternal"),
 
-				new WhileInstruction(new InequalityExpression(new VariableExpression("flag"), new LiteralExpression(false)), "while"),
-				new EmptyStatement(),
-				new EndWhileInstruction("while"),
+                new WhileInstruction(new InequalityExpression(new VariableExpression("flag"), new LiteralExpression(false)), "while"),
+                new EmptyStatement(),
+                new EndWhileInstruction("while"),
 
-				createAssignment("flag", new LiteralExpression(true)),
+                createAssignment("flag", new LiteralExpression(true)),
 
-				new CriticalSectionInstruction(),
+                new CriticalSectionInstruction(),
 
-				createAssignment("flag", new LiteralExpression(false)),
+                createAssignment("flag", new LiteralExpression(false)),
 
-				new EndWhileInstruction("eternal")
-			], "Second Army")
-		],
-		{
-			"flag" : {
-				name : "flag",
-				type : "System.Boolean",
-				value : false
-			}
-		}
-	),
-	"3-simpleCounter" : new Level(
-		"3-simpleCounter",
-		"Simple Counter",
-		"Is the Deadlock Empire stupid?",
-		"<div class='story-intro'>The Parallel Wizard, leader of the Deadlock Empire, has unleashed the first Dragons upon you - these are terrifying creatures but for some reason, these two dragons appear to have critical weakspots specifically designed to be weak. Maybe you can exploit that, Scheduler.</div> <div>Here also you must make both threads enter the critical section.<br>If you'd like to reset the counter, use the orange <span class='tutorial-button-mock'>Reset level</span> button on the right.</div>",
-		"<div class='story-outro'>Yes, the dragons are both defeated! But we have just received news that the Empire is sending more of their monsters at your towns. You can't be everywhere, Scheduler, and we win wherever you go, but you should know that each passing hour more villages fall to the dread Empire.</div>" +
-		"As you have seen previously, once you pass a test, such as an integer comparison, you don't care about what other threads do to the operands - you have already passed the test and may continue to the critical section. To fix this program, locks would be needed.",
-		[
-			new Thread([
-				new WhileInstruction(new LiteralExpression(true), "while"),						createIncrement("counter"),
-				new IfInstruction(new EqualityExpression(new VariableExpression("counter"), new LiteralExpression(5)), "if"),
-				new CriticalSectionInstruction(),
-				new EndIfInstruction("if"),
-				new EndWhileInstruction("while")
-			], "Five-Headed Dragon"),
-			new Thread([
-				new WhileInstruction(new LiteralExpression(true), "while"), 				createIncrement("counter"),
-				new IfInstruction(new EqualityExpression(new VariableExpression("counter"), new LiteralExpression(3)), "if"),
-				new CriticalSectionInstruction(),
-				new EndIfInstruction("if"),
-				new EndWhileInstruction("while")
-			], "Three-Headed Dragon")
-		],
-		{
-			"counter": {
-				name: "counter",
-				type: "System.Int32",
-				value : 0
-			}
-		}
-	),
-	"4-confusedCounter" : new Level(
-		"4-confusedCounter",
-		"Confused Counter",
-		"Could it be that some instructions are hidden from sight?",
-		"<div class='story-intro'>The Parallel Wizard is now more cunning and the dragons he designs and the armies he trains are more resilient than ever. But still they must be defeated, or else the entire world will fall to the Empire and we will all be forced to learn parallel programming!</div>Could it be that some instructions are hidden from sight?<br><br>Most instructions are <i>not</i> atomic. That means that context may switch during the instruction's execution. For assignments, for example, it means that the expression may be read into registers of a thread, but then context may switch and when the thread receives priority again, it won't read the expression again, it will simply write the register into the left-hand variable.<br><br>To win this level, you must <b>execute</b> the <i>failure instruction</i>. It represents a point in the program that should never be executed normally.",
-		"<div class='story-outro'>And yet again the Wizard's tactics have been foiled! Hurray for simplicity!</div>",
-		[
-			new Thread([
-				new FlavorInstruction("business_logic()"),
-				createIncrement("first"),
-				createIncrement("second"),
-				new IfInstruction(new AndExpression(
-					new EqualityExpression(new VariableExpression("second"), new LiteralExpression(2)),
-					new InequalityExpression(new VariableExpression("first"), new LiteralExpression(2))), "if"),
-				new FailureInstruction(),
-				new EndIfInstruction("if")
-			]),
-			new Thread([
-				new FlavorInstruction("business_logic()"),
-				createIncrement("first"),
-				createIncrement("second")
-			])
-		],
-		{
-			"first": {
-				name: "first",
-				type: "System.Int32",
-				value : 0
-			},
-			"second": {
-				name: "second",
-				type: "System.Int32",
-				value : 0
-			}
-		}
-	),
-	"5-peterson": new Level(
-		"5-peterson",
-		"Three-way Peterson Algorithm",
-		"This riddle is rather fiendish.",
-		"The Peterson Algorithm is the best known way for 2 threads to synchronize without the use of any synchronization primitives except for atomic value read and atomic value write. However, does a straightforward generalization for multiple threads work?<br><br>(Hint: It doesn't. You won't be able to break this algorithm. However, note that the threads are forced to cycle. If one thread stops cooperating and does not want to enter the critical section anymore, the remaining two threads will be stuck in infinite loops, waiting.)",
-		"As you saw, it does not. However, there is still a way to do mutual exclusion for three threads with only atomic value read and atomic value write. This method is also called Peterson's Algorithm, but it is not used in practice because solutions using more advanced atomic operations are faster and even methods using locks are more efficient.",
-		[
-			new Thread([
-				new WhileInstruction(new LiteralExpression(true), "eternal"),
-				createAssignment("flag1", new LiteralExpression(true)),
-				createAssignment("turn", new LiteralExpression(2)),
-				new WhileInstruction(new AndExpression(
-					new OrExpression(
-						new VariableExpression("flag2"),
-						new VariableExpression("flag3")
-					),
-					new OrExpression(
-						new EqualityExpression(new VariableExpression("turn"), new LiteralExpression(2)),
-						new EqualityExpression(new VariableExpression("turn"), new LiteralExpression(3))
-					)
-				), "wait", "while ((flag2 || flag3) &&\n         (turn == 2 || turn == 3)) {"),
-				new EmptyStatement(),
-				new EndWhileInstruction("wait"),
-				new CriticalSectionInstruction(),
-				createAssignment("flag1", new LiteralExpression(false)),
-				new EndWhileInstruction("eternal")
-			]),
+                new EndWhileInstruction("eternal")
+            ], "Second Army")
+        ],
+        {
+            "flag" : {
+                name : "flag",
+                type : "System.Boolean",
+                value : false
+            }
+        }
+    ),
+    "3-simpleCounter" : new Level(
+        "3-simpleCounter",
+        "Simple Counter",
+        "Is the Deadlock Empire stupid?",
+        "<div class='story-intro'>The Parallel Wizard, leader of the Deadlock Empire, has unleashed the first Dragons upon you - these are terrifying creatures but for some reason, these two dragons appear to have critical weakspots specifically designed to be weak. Maybe you can exploit that, Scheduler.</div> <div>Here also you must make both threads enter the critical section.<br>If you'd like to reset the counter, use the orange <span class='tutorial-button-mock'>Reset level</span> button on the right.</div>",
+        "<div class='story-outro'>Yes, the dragons are both defeated! But we have just received news that the Empire is sending more of their monsters at your towns. You can't be everywhere, Scheduler, and we win wherever you go, but you should know that each passing hour more villages fall to the dread Empire.</div>" +
+        "As you have seen previously, once you pass a test, such as an integer comparison, you don't care about what other threads do to the operands - you have already passed the test and may continue to the critical section. To fix this program, locks would be needed.",
+        [
+            new Thread([
+                new WhileInstruction(new LiteralExpression(true), "while"),
+                createIncrement("counter"),
+                new IfInstruction(new EqualityExpression(new VariableExpression("counter"), new LiteralExpression(5)), "if"),
+                new CriticalSectionInstruction(),
+                new EndIfInstruction("if"),
+                new EndWhileInstruction("while")
+            ], "Five-Headed Dragon"),
+            new Thread([
+                new WhileInstruction(new LiteralExpression(true), "while"),
+                createIncrement("counter"),
+                new IfInstruction(new EqualityExpression(new VariableExpression("counter"), new LiteralExpression(3)), "if"),
+                new CriticalSectionInstruction(),
+                new EndIfInstruction("if"),
+                new EndWhileInstruction("while")
+            ], "Three-Headed Dragon")
+        ],
+        {
+            "counter": {
+                name: "counter",
+                type: "System.Int32",
+                value : 0
+            }
+        }
+    ),
+    "4-confusedCounter" : new Level(
+        "4-confusedCounter",
+        "Confused Counter",
+        "Could it be that some instructions are hidden from sight?",
+        "<div class='story-intro'>The Parallel Wizard is now more cunning and the dragons he designs and the armies he trains are more resilient than ever. But still they must be defeated, or else the entire world will fall to the Empire and we will all be forced to learn parallel programming!</div>Could it be that some instructions are hidden from sight?<br><br>Most instructions are <i>not</i> atomic. That means that context may switch during the instruction's execution. For assignments, for example, it means that the expression may be read into registers of a thread, but then context may switch and when the thread receives priority again, it won't read the expression again, it will simply write the register into the left-hand variable.<br><br>To win this level, you must <b>execute</b> the <i>failure instruction</i>. It represents a point in the program that should never be executed normally.",
+        "<div class='story-outro'>And yet again the Wizard's tactics have been foiled! Hurray for simplicity!</div>",
+        [
+            new Thread([
+                new FlavorInstruction("business_logic()"),
+                createIncrement("first"),
+                createIncrement("second"),
+                new IfInstruction(new AndExpression(
+                    new EqualityExpression(new VariableExpression("second"), new LiteralExpression(2)),
+                    new InequalityExpression(new VariableExpression("first"), new LiteralExpression(2))), "if"),
+                new FailureInstruction(),
+                new EndIfInstruction("if")
+            ]),
+            new Thread([
+                new FlavorInstruction("business_logic()"),
+                createIncrement("first"),
+                createIncrement("second")
+            ])
+        ],
+        {
+            "first": {
+                name: "first",
+                type: "System.Int32",
+                value : 0
+            },
+            "second": {
+                name: "second",
+                type: "System.Int32",
+                value : 0
+            }
+        }
+    ),
+    "5-peterson": new Level(
+        "5-peterson",
+        "Three-way Peterson's Algorithm",
+        "This riddle is rather fiendish.",
+        "The <a href='https://en.wikipedia.org/wiki/Peterson%27s_algorithm'>Peterson's Algorithm</a> is the best known way for 2 threads to synchronize without the use of any synchronization primitives except for atomic value read and atomic value write. However, does a straightforward generalization for multiple threads work?<br><br>(Hint: It doesn't. You won't be able to break this algorithm. However, note that the threads are forced to cycle. If one thread stops cooperating and does not want to enter the critical section anymore, the remaining two threads will be stuck in infinite loops, waiting.)",
+        "As you saw, it does not. However, there is still a way to do mutual exclusion for three threads with only atomic value read and atomic value write. This method is also called Peterson's Algorithm, but it is not used in practice because solutions using more advanced atomic operations are faster and even methods using locks are more efficient.",
+        [
+            new Thread([
+                new WhileInstruction(new LiteralExpression(true), "eternal"),
+                createAssignment("flag1", new LiteralExpression(true)),
+                createAssignment("turn", new LiteralExpression(2)),
+                new WhileInstruction(new AndExpression(
+                    new OrExpression(
+                        new VariableExpression("flag2"),
+                        new VariableExpression("flag3")
+                    ),
+                    new OrExpression(
+                        new EqualityExpression(new VariableExpression("turn"), new LiteralExpression(2)),
+                        new EqualityExpression(new VariableExpression("turn"), new LiteralExpression(3))
+                    )
+                ), "wait", "while ((flag2 || flag3) &&\n         (turn == 2 || turn == 3)) {"),
+                new EmptyStatement(),
+                new EndWhileInstruction("wait"),
+                new CriticalSectionInstruction(),
+                createAssignment("flag1", new LiteralExpression(false)),
+                new EndWhileInstruction("eternal")
+            ]),
 
-			new Thread([
-				new WhileInstruction(new LiteralExpression(true), "eternal"),
-				createAssignment("flag2", new LiteralExpression(true)),
-				createAssignment("turn", new LiteralExpression(3)),
-				new WhileInstruction(new AndExpression(
-					new OrExpression(
-						new VariableExpression("flag1"),
-						new VariableExpression("flag3")
-					),
-					new OrExpression(
-						new EqualityExpression(new VariableExpression("turn"), new LiteralExpression(1)),
-						new EqualityExpression(new VariableExpression("turn"), new LiteralExpression(3))
-					)
-				), "wait", "while ((flag1 || flag3) &&\n         (turn == 1 || turn == 3)) {"),
-				new EmptyStatement(),
-				new EndWhileInstruction("wait"),
-				new CriticalSectionInstruction(),
-				createAssignment("flag2", new LiteralExpression(false)),
-				new EndWhileInstruction("eternal")
-			]),
+            new Thread([
+                new WhileInstruction(new LiteralExpression(true), "eternal"),
+                createAssignment("flag2", new LiteralExpression(true)),
+                createAssignment("turn", new LiteralExpression(3)),
+                new WhileInstruction(new AndExpression(
+                    new OrExpression(
+                        new VariableExpression("flag1"),
+                        new VariableExpression("flag3")
+                    ),
+                    new OrExpression(
+                        new EqualityExpression(new VariableExpression("turn"), new LiteralExpression(1)),
+                        new EqualityExpression(new VariableExpression("turn"), new LiteralExpression(3))
+                    )
+                ), "wait", "while ((flag1 || flag3) &&\n         (turn == 1 || turn == 3)) {"),
+                new EmptyStatement(),
+                new EndWhileInstruction("wait"),
+                new CriticalSectionInstruction(),
+                createAssignment("flag2", new LiteralExpression(false)),
+                new EndWhileInstruction("eternal")
+            ]),
 
-			new Thread([
-				new WhileInstruction(new LiteralExpression(true), "eternal"),
-				createAssignment("flag3", new LiteralExpression(true)),
-				createAssignment("turn", new LiteralExpression(1)),
-				new WhileInstruction(new AndExpression(
-					new OrExpression(
-						new VariableExpression("flag2"),
-						new VariableExpression("flag1")
-					),
-					new OrExpression(
-						new EqualityExpression(new VariableExpression("turn"), new LiteralExpression(2)),
-						new EqualityExpression(new VariableExpression("turn"), new LiteralExpression(1))
-					)
-				), "wait", "while ((flag2 || flag1) &&\n         (turn == 2 || turn == 1)) {"),
-				new EmptyStatement(),
-				new EndWhileInstruction("wait"),
-				new CriticalSectionInstruction(),
-				createAssignment("flag3", new LiteralExpression(false)),
-				new EndWhileInstruction("eternal")
-			])
+            new Thread([
+                new WhileInstruction(new LiteralExpression(true), "eternal"),
+                createAssignment("flag3", new LiteralExpression(true)),
+                createAssignment("turn", new LiteralExpression(1)),
+                new WhileInstruction(new AndExpression(
+                    new OrExpression(
+                        new VariableExpression("flag2"),
+                        new VariableExpression("flag1")
+                    ),
+                    new OrExpression(
+                        new EqualityExpression(new VariableExpression("turn"), new LiteralExpression(2)),
+                        new EqualityExpression(new VariableExpression("turn"), new LiteralExpression(1))
+                    )
+                ), "wait", "while ((flag2 || flag1) &&\n         (turn == 2 || turn == 1)) {"),
+                new EmptyStatement(),
+                new EndWhileInstruction("wait"),
+                new CriticalSectionInstruction(),
+                createAssignment("flag3", new LiteralExpression(false)),
+                new EndWhileInstruction("eternal")
+            ])
 
-		],
-		{
-			"flag1" : {
-				name : "flag1",
-				type : "System.Boolean",
-				value : false
-			},
-			"flag2" : {
-				name : "flag2",
-				type : "System.Boolean",
-				value : false
-			},
-			"flag3" : {
-				name : "flag3",
-				type : "System.Boolean",
-				value : false
-			},
-			turn : {
-				name : "turn",
-				type : "System.Int32",
-				value : 2
-			}
-		}
-	),
-	"L1-lock": new Level(
-		"L1-lock",
-		"Insufficient Lock",
-		"Locks don't solve everything.",
-		"<div class='story-intro'>The Deadlock Empire strikes again, and in force!<br><br>" +
-		"Their dragons still have critical sections where they are weak, but this time, they have brought armored locks to hide them from us. Our artillery is not powerful enough to punch through this armor or to defeat the dragons without exploiting the critical sections. It falls upon you, Scheduler, to reveal to us a way to access the critical sections, even under the armored locks.</div>" +
-		"<i>Locks</i> (or <i>mutexes</i>, from <i>mut</i>ual <i>ex</i>clusion) disallow more threads from running some code at the same time. At any point in time, a lock is either <i>locked</i> (or <i>held</i>) by one thread, or it's <i>unlocked</i>. Locks have two basic operations: <i>locking</i> and <i>unlocking</i>.<br><br>" +
-		"When thread X tries to <i>lock</i> an unlocked lock L, the lock is granted to X and nobody else can lock L again until X <i>unlocks</i> it. " +
-		"On the other hand, if L is already held by another thread Y, X cannot obtain the lock L. You can usually choose what happens then: common options are <i>\"block until Y releases L and retry\"</i>, <i>\"try to lock L immediately, fail if L is locked\"</i>, and <i>\"wait for Y to unlock L, but give up after a timeout period\"</i>. <br><br>" +
-		"You might wonder why do we need the <i>\"block until Y releases L and retry\"</i> option: you could accomplish something similar by using <i>\"try to lock immediately\"</i> in a loop: <code>while (!locked) { if (TryLock(obj) { break; } }</code>. (This pattern is called a <i>spinlock</i>.) The problem with this loop is that it <i>actively waits</i>. If you let this loop run for 1 second without letting the thread that holds the lock progress, it will just keep reentering the loop, without any hope of progress until the lock is released (by another thread). Basically, the computer just burns CPU cycles when it runs this code. The option that blocks until we manage to grab the lock tells the runtime: \"We can't go on until this other thread releases this lock, so don't even schedule us until that happens.\"<br><br>" +
-		"If more threads are waiting on the same lock, one of them will lock it when it unlocks, but you can't make any assumptions about which one will win.<br><br>" +
-		"In C# (unlike, for example, C++), there is no designated type for locks. Instead, all <code>object</code>s (including any classes) can act as locks and can be locked and unlocked via the <a href='https://msdn.microsoft.com/en-us/library/system.threading.monitor.aspx'>System.Threading.Monitor</a> static class.<br><br>" +
-		"For our purposes, we will only need <code>Monitor.Enter(obj)</code>, which locks <code>obj</code> (or waits until it unlocks and retries) and <code>Monitor.Exit(obj)</code>, which unlocks it. C# <code>Monitor</code>s are a cross between <i>locks</i> and <i>condition variables</i> (which you shall conquer later).<br><br>" +
-		"Finally, a lot of C# code just uses a simple pattern of locking provided by the <code>lock</code> statement, which handles most common cases nicely and is easier than fiddling with <code>Monitor</code>. <code>lock (obj) { ... }</code> is translated by the compiler to a <code>Monitor.Enter</code>/<code>Exit</code> pair on <code>obj</code>. As a bonus, it also properly handles exceptions. It's easy to forget this when you use <code>Monitor</code> directly: if anything between <code>Enter</code> and <code>Exit</code> throws an exception and the lock is not released by an exception handler (e.g., in a <code>finally</code> block), it forever remains locked by the thread which threw the exception, which is not good.<br><br>" +
-		"Have a look at the <a href='https://msdn.microsoft.com/en-us/library/c5kehkcz.aspx'>documentation for the lock statement</a> if you'd like to know more.<br><br>Play with these two threads. See what happens when you lock the lock in one thread and try to lock it again in another one?" +
-		"",
-		"<div class='story-outro'>As soon as you revealed to us the way to get under the lock armor, our mages let out a volley of cold fire against the dragons. We slaughtered them and as the dragons fell, the invading army retreated.</div>" +
-		"Locks are the most commonly used synchronization primitive. It is very useful to know them.",
-		[
-			new Thread([
-				createOuterWhile(),
-				new MonitorEnterInstruction("mutex"),
-				createAssignment("i", new AdditionExpression(new VariableExpression("i"), new LiteralExpression(2))),
-				new CriticalSectionInstruction(),
-				new IfInstruction(new EqualityExpression(new VariableExpression("i"), new LiteralExpression(5)), "if"),
-				new FailureInstruction(),
-				new EndIfInstruction("if"),
-				new MonitorExitInstruction("mutex"),
-				createOuterWhileEnd()
-			]), new Thread([
-				createOuterWhile(),
-				new MonitorEnterInstruction("mutex"),
-				createAssignment("i", new SubtractionExpression(new VariableExpression("i"), new LiteralExpression(1))),
-				new CriticalSectionInstruction(),
-				new MonitorExitInstruction("mutex"),
-				createOuterWhileEnd()
-		])
-		],
-		{
-			"mutex": {
-				name : "mutex",
-				type : "System.Object",
-				value : "unimportant"
-			},
-			"i": {
-				name : "i",
-				type : "System.Int32",
-				value : 0
-			}
-		}
-	),
-	"L2-deadlock": new Level(
-		"L2-deadlock",
-		"Deadlock",
-		"Stop the Empire army in its tracks!",
-		"<div class='story-intro'>Encouraged by your victory against the armored dragons, you move on to the Refactor Lands, a critical territory where the Deadlock Empire is always trying to recruit more towns to convert to their paradigms. Even now, they are moving a great army to this territory in the hope of intimidating developers to accept their teachings. This must not be allowed to happen.</div>A '<a href='http://en.wikipedia.org/wiki/Deadlock' target='_blank'>deadlock</a>' is a scenario where all threads in the program wait for each other to release some resource (usually locks). None of them is willing to concede a resource before the other ones and thus the program is stuck - forever waiting for locks which will never be released. In this game, if you cause a deadlock to occur, you win the challenge immediately.",
-		"<div class='story-outro'>Today you have scored an important victory! Not only are the armies blocked from moving forward but the people of Refactor Lands have seen the problems that come with parallel programming and praise you and say they will gladly stay with a sequentialist design. Now only one thing remains to be done here - plant a flag atop the local hill.</div>This was the most simple deadlock scenario - two threads mutually waiting for each other, because each was stuck on a different lock. Congratulations all the same for solving it!<br>" +
-		"To avoid deadlocks in your programs, be very dilligent whenever you grab multiple locks. If two threads need the same locks, locking and unlocking them in the same order in both threads is one way to avoid deadlocking the two threads.",
-		[
-			new Thread([
-				new MonitorEnterInstruction("mutex"),
-				new MonitorEnterInstruction("mutex2"),
-				new CriticalSectionInstruction(),
-				new MonitorExitInstruction("mutex"),
-				new MonitorExitInstruction("mutex2")
-			]),
-			new Thread([
-				new MonitorEnterInstruction("mutex2"),
-				new MonitorEnterInstruction("mutex"),
-				new CriticalSectionInstruction(),
-				new MonitorExitInstruction("mutex2"),
-				new MonitorExitInstruction("mutex")
-			])
-		],
-		{
-			"mutex" : {
-				name : "mutex",
-				type : "System.Object",
-				value : "unimportant"
-			},
-			"mutex2" : {
-				name : "mutex2",
-				type : "System.Object",
-				value : "unimportant"
-			}
+        ],
+        {
+            "flag1" : {
+                name : "flag1",
+                type : "System.Boolean",
+                value : false
+            },
+            "flag2" : {
+                name : "flag2",
+                type : "System.Boolean",
+                value : false
+            },
+            "flag3" : {
+                name : "flag3",
+                type : "System.Boolean",
+                value : false
+            },
+            turn : {
+                name : "turn",
+                type : "System.Int32",
+                value : 2
+            }
+        }
+    ),
+    "L1-lock": new Level(
+        "L1-lock",
+        "Insufficient Lock",
+        "Locks don't solve everything.",
+        "<div class='story-intro'>The Deadlock Empire strikes again, and in force!<br><br>" +
+        "Their dragons still have critical sections where they are weak, but this time, they have brought armored locks to hide them from us. Our artillery is not powerful enough to punch through this armor or to defeat the dragons without exploiting the critical sections. It falls upon you, Scheduler, to reveal to us a way to access the critical sections, even under the armored locks.</div>" +
+        "<i>Locks</i> (or <i>mutexes</i>, from <i>mut</i>ual <i>ex</i>clusion) disallow more threads from running some code at the same time. At any point in time, a lock is either <i>locked</i> (or <i>held</i>) by one thread, or it's <i>unlocked</i>. Locks have two basic operations: <i>locking</i> and <i>unlocking</i>.<br><br>" +
+        "When thread X tries to <i>lock</i> an unlocked lock L, the lock is granted to X and nobody else can lock L again until X <i>unlocks</i> it. " +
+        "On the other hand, if L is already held by another thread Y, X cannot obtain the lock L. You can usually choose what happens then: common options are <i>\"block until Y releases L and retry\"</i>, <i>\"try to lock L immediately, fail if L is locked\"</i>, and <i>\"wait for Y to unlock L, but give up after a timeout period\"</i>. <br><br>" +
+        "You might wonder why do we need the <i>\"block until Y releases L and retry\"</i> option: you could accomplish something similar by using <i>\"try to lock immediately\"</i> in a loop: <code>while (!locked) { if (TryLock(obj) { break; } }</code>. (This pattern is called a <i>spinlock</i>.) The problem with this loop is that it <i>actively waits</i>. If you let this loop run for 1 second without letting the thread that holds the lock progress, it will just keep reentering the loop, without any hope of progress until the lock is released (by another thread). Basically, the computer just burns CPU cycles when it runs this code. The option that blocks until we manage to grab the lock tells the runtime: \"We can't go on until this other thread releases this lock, so don't even schedule us until that happens.\"<br><br>" +
+        "If more threads are waiting on the same lock, one of them will lock it when it unlocks, but you can't make any assumptions about which one will win.<br><br>" +
+        "In C# (unlike, for example, C++), there is no designated type for locks. Instead, all <code>object</code>s (including any classes) can act as locks and can be locked and unlocked via the <a href='https://msdn.microsoft.com/en-us/library/system.threading.monitor.aspx'>System.Threading.Monitor</a> static class.<br><br>" +
+        "For our purposes, we will only need <code>Monitor.Enter(obj)</code>, which locks <code>obj</code> (or waits until it unlocks and retries) and <code>Monitor.Exit(obj)</code>, which unlocks it. C# <code>Monitor</code>s are a cross between <i>locks</i> and <i>condition variables</i> (which you shall conquer later).<br><br>" +
+        "Finally, a lot of C# code just uses a simple pattern of locking provided by the <code>lock</code> statement, which handles most common cases nicely and is easier than fiddling with <code>Monitor</code>. <code>lock (obj) { ... }</code> is translated by the compiler to a <code>Monitor.Enter</code>/<code>Exit</code> pair on <code>obj</code>. As a bonus, it also properly handles exceptions. It's easy to forget this when you use <code>Monitor</code> directly: if anything between <code>Enter</code> and <code>Exit</code> throws an exception and the lock is not released by an exception handler (e.g., in a <code>finally</code> block), it forever remains locked by the thread which threw the exception, which is not good.<br><br>" +
+        "Have a look at the <a href='https://msdn.microsoft.com/en-us/library/c5kehkcz.aspx'>documentation for the lock statement</a> if you'd like to know more.<br><br>Play with these two threads. See what happens when you lock the lock in one thread and try to lock it again in another one?" +
+        "",
+        "<div class='story-outro'>As soon as you revealed to us the way to get under the lock armor, our mages let out a volley of cold fire against the dragons. We slaughtered them and as the dragons fell, the invading army retreated.</div>" +
+        "Locks are the most commonly used synchronization primitive. It is very useful to know them.",
+        [
+            new Thread([
+                createOuterWhile(),
+                new MonitorEnterInstruction("mutex"),
+                createAssignment("i", new AdditionExpression(new VariableExpression("i"), new LiteralExpression(2))),
+                new CriticalSectionInstruction(),
+                new IfInstruction(new EqualityExpression(new VariableExpression("i"), new LiteralExpression(5)), "if"),
+                new FailureInstruction(),
+                new EndIfInstruction("if"),
+                new MonitorExitInstruction("mutex"),
+                createOuterWhileEnd()
+            ]), new Thread([
+                createOuterWhile(),
+                new MonitorEnterInstruction("mutex"),
+                createAssignment("i", new SubtractionExpression(new VariableExpression("i"), new LiteralExpression(1))),
+                new CriticalSectionInstruction(),
+                new MonitorExitInstruction("mutex"),
+                createOuterWhileEnd()
+        ])
+        ],
+        {
+            "mutex": {
+                name : "mutex",
+                type : "System.Object",
+                value : "unimportant"
+            },
+            "i": {
+                name : "i",
+                type : "System.Int32",
+                value : 0
+            }
+        }
+    ),
+    "L2-deadlock": new Level(
+        "L2-deadlock",
+        "Deadlock",
+        "Stop the Empire army in its tracks!",
+        "<div class='story-intro'>Encouraged by your victory against the armored dragons, you move on to the Refactor Lands, a critical territory where the Deadlock Empire is always trying to recruit more towns to convert to their paradigms. Even now, they are moving a great army to this territory in the hope of intimidating developers to accept their teachings. This must not be allowed to happen.</div>A '<a href='http://en.wikipedia.org/wiki/Deadlock' target='_blank'>deadlock</a>' is a scenario where all threads in the program wait for each other to release some resource (usually locks). None of them is willing to concede a resource before the other ones and thus the program is stuck - forever waiting for locks which will never be released. In this game, if you cause a deadlock to occur, you win the challenge immediately.",
+        "<div class='story-outro'>Today you have scored an important victory! Not only are the armies blocked from moving forward but the people of Refactor Lands have seen the problems that come with parallel programming and praise you and say they will gladly stay with a sequentialist design. Now only one thing remains to be done here - plant a flag atop the local hill.</div>This was the most simple deadlock scenario - two threads mutually waiting for each other, because each was stuck on a different lock. Congratulations all the same for solving it!<br>" +
+        "To avoid deadlocks in your programs, be very dilligent whenever you grab multiple locks. If two threads need the same locks, locking and unlocking them in the same order in both threads is one way to avoid deadlocking the two threads.",
+        [
+            new Thread([
+                new MonitorEnterInstruction("mutex"),
+                new MonitorEnterInstruction("mutex2"),
+                new CriticalSectionInstruction(),
+                new MonitorExitInstruction("mutex"),
+                new MonitorExitInstruction("mutex2")
+            ]),
+            new Thread([
+                new MonitorEnterInstruction("mutex2"),
+                new MonitorEnterInstruction("mutex"),
+                new CriticalSectionInstruction(),
+                new MonitorExitInstruction("mutex2"),
+                new MonitorExitInstruction("mutex")
+            ])
+        ],
+        {
+            "mutex" : {
+                name : "mutex",
+                type : "System.Object",
+                value : "unimportant"
+            },
+            "mutex2" : {
+                name : "mutex2",
+                type : "System.Object",
+                value : "unimportant"
+            }
 
-		}
-	),
-	"L3-complexer": new Level(
-		"L3-complexer",
-		"A More Complex Thread",
-		"Three locks, two threads, one flag.",
-		"<span class='story-intro'>You look up the Refactor Lands hill at the lone flag that shows who controls this important territory. You climb fast - you must reach it first. Unfortunately, that won't happen - not one, not two, but three enemy armies are closing in on the hill and they will all reach the flag before you do. You must do something about this, stop them somehow, if you are to claim this territory and save the poor people of Refactor Lands the trouble of changing paradigms.</span><br><br>" +
-		"This may appear difficult at first. There's a lot of locks, a boolean flag and critical sections. The code is not very readable and an error could be anywhere. In fact, it wouldn't surprise us if you found a solution to this challenge different from what we thought of when creating it. You should definitely write more concise and understandable code than this.<br><br>" +
-		"Even so, you might use this advice: In C#, locks can be locked recursively. For example, a thread can <i>lock</i> (via <i>Monitor.Enter</i>) a single object multiple times. In order to release the lock on that object and permit other threads to lock it, <i>all</i> of the locks must be released, i.e. the method <i>Monitor.Exit</i> must be called the same number of times as <i>Monitor.Enter</i>.<br><br>" +
-		"You did not encounter <code><a href='https://msdn.microsoft.com/en-us/library/system.threading.monitor.tryenter'>Monitor.TryEnter()</a></code> yet. It does exactly what it says on the tin: it tries to lock a lock if possible. If the lock is unlocked, it locks it and returns <code>true</code>. Otherwise, the lock remains locked by its owner and the method returns <code>false</code>.<br><br>",
-		"<span class='story-outro'>You replace the neutral flag with the sign of the Sequentialists. You have won. Smiling, you look down from the hill at the three armies locked in place - neither able to move. Once again, you have proven the uselessness of parallelism.</span><br><br>The <b><a href='https://msdn.microsoft.com/en-us/library/system.threading.monitor.tryenter'>Monitor.TryEnter()</a></b> method, if successful, also locks the mutex and in C#, objects can be locked recursively. In order for a lock to be released, it must be <i>exited</i> the same number of times it was <i>entered</i>. In this game, you saw that there is no matching <i>Monitor.Exit()</i> call to the <i>.TryEnter()</i> call and thus the first thread was able to lock the object, recursively, many times, making it impossible for the second thread to lock it.",
-		[
-			new Thread([
-				createOuterWhile(),
-				new IfLongInstruction(new MonitorTryEnterExpression("mutex"), "if"),
-				new MonitorEnterInstruction("mutex3"),
-				new MonitorEnterInstruction("mutex"),
-				new CriticalSectionInstruction(),
-				new MonitorExitInstruction("mutex"),
-				new MonitorEnterInstruction("mutex2"),
-				createAssignment("flag", new LiteralExpression(false)),
-				new MonitorExitInstruction("mutex2"),
-				new MonitorExitInstruction("mutex3"),
-				new ElseInstruction("if"),
-				new MonitorEnterInstruction("mutex2"),
-				createAssignment("flag", new LiteralExpression(true)),
-				new MonitorExitInstruction("mutex2"),
-				new EndIfLongInstruction("if"),
-				createOuterWhileEnd()
-			]),
-			new Thread([
-				createOuterWhile(),
-				new IfLongInstruction(new VariableExpression("flag"), "if"),
-				new MonitorEnterInstruction("mutex2"),
-				new MonitorEnterInstruction("mutex"),
-				createAssignment("flag", new LiteralExpression(false)),
-				new CriticalSectionInstruction(),
-				new MonitorExitInstruction("mutex"),
-				new MonitorEnterInstruction("mutex2"),
-				new ElseInstruction("if"),
-				new MonitorEnterInstruction("mutex"),
-				createAssignment("flag", new LiteralExpression(false)),
-				new MonitorExitInstruction("mutex"),
-				new EndIfLongInstruction("if"),
-				createOuterWhileEnd()
-			])
-		],
-		{
-			"mutex" : new ObjectVariable("mutex"),
-			"mutex2" : new ObjectVariable("mutex2"),
-			"mutex3" :  new ObjectVariable("mutex3"),
-			"flag":  {
-				name : "flag",
-				type : "System.Boolean",
-				value : false
-			}
-		}
-	),
-	"S1-simple" : new Level(
-		"S1-simple",
-		"Semaphores",
-		"A semaphore is a simple synchronization primitive.",
-		"<div class='story-intro'>You behold the Factory Lands of the Deadlock Empire. You are almost in awe. Everything runs smoothly and efficiently, all factories producing new materials at the same time without unnecessary delays, everything manned by thousands of workers. Cooperation. But there are weaknesses - it may be efficient but it is unstable. A single mistake - anywhere - can bring entire factories down. You take one look at the fearsome mechanical dragons leaving the factories on numerous conveyor bolts and your determination is sealed. You will destroy this land.</div>" +
-		"<a href='https://msdn.microsoft.com/en-us/library/system.threading.semaphoreslim(v=vs.110).aspx'>Semaphores</a> limit the number of threads that can access a resource at the same time. In C#, they are implemented by the SemaphoreSlim class." +
-		"You can imagine a semaphore as a stack of coins. When a thread wants to access the resource protected by the semaphore, it needs to take a coin. Once it's done, it returns the coin to the stack.<br>" +
-		"To take a coin, you can call the <code><a href='https://msdn.microsoft.com/en-us/library/dd270787(v=vs.110).aspx'>Wait()</a></code> method on the semaphore. If there are no coins on the stack, the method waits until someone returns a coin. If you don't want to wait forever, you can pass it how long should it wait, in milliseconds. In that case, <code>Wait()</code> will return a boolean indicating whether it obtained a coin.<br>" +
-		"The <code><a href='https://msdn.microsoft.com/en-us/library/dd235727(v=vs.110).aspx'>Release()</a></code> method adds a coin on the stack. Normally, you would call <code>Release()</code> only after a <code>Wait()</code> - you would take a coin, do something while you have it, and then give it back. However, you can also call <code>Release()</code> while you don't have any coins yourself. If you let Thread 1 run, you will see it do this: if it can't find a coin within 500 milliseconds, it will create a new one.<br><br>" +
-		"The two threads below try to use a semaphore to ensure they don't enter the critical section at the same time. Can you figure out what are they doing wrong?",
-		"<div class='story-outro'>A few factories stopped but the Parallel Wizard is hard at work repairing them. You must move on and act quickly to capitalize on this.</div>",
-		[
-			new Thread([
-				createOuterWhile(),
-				new SemaphoreWaitInstruction("ss"),
-				new CriticalSectionInstruction(),
-				new SemaphoreReleaseInstruction("ss"),
-				createOuterWhileEnd()
-			]),
-			new Thread([
-				createOuterWhile(),
-				new IfLongInstruction(new SemaphoreTryWaitExpression("ss"), "if"),
-				new CriticalSectionInstruction(),
-				new SemaphoreReleaseInstruction("ss"),
-				new ElseInstruction("if"),
-				new SemaphoreReleaseInstruction("ss"),
-				new EndIfLongInstruction("if"),
-				createOuterWhileEnd()
-			])
-		],
-		{
-			"ss" : new SemaphoreVariable("ss", 0)
-		}
-	),
-	"S2-producerConsumer" : new Level(
-		"S2-producerConsumer",
-		"Producer-Consumer",
-		"A new victory condition awaits you!",
-		"<div class='story-intro'>You pick your target - one dragon-producing factory is sending its creations directly into an armory that outfits the machines with destructive weapons. If you disrupt this supply line, you will greatly reduce the number of dragons at the Empire's disposal.</div>" +
-		"In <a href='https://en.wikipedia.org/wiki/Producer–consumer_problem'>producer-consumer scenarios</a>, one thread produces some items that another thread consumes. " +
-		"For example, one thread could accept work requests from a user, and another thread could take outstanding requests and fulfill them.<br>" +
-		"Even through the producer-consumer problem might look trivial, it has some subtle complexity to it. For example, what if the consumer needs a lot of time to consume one item, while the producer produces items as fast as it can? We could run out of memory.<br>" +
-		'Semaphores are useful for producer-consumer problems. Remember the "coin stack" analogy: each item in the queue is represented by a coin; when the producer produces a new one, it adds a coin, and when the consumer consumes an item, it removes a coin.<br><br>' +
-		"In this challenge, your goal is cause an exception to be raised.<br>",
-		"<div class='story-outro'>Alarms sound over the lands but you hear only the sweet sound of victory. Soon, the Sequentialists will win and everything will happen in order, as was meant to be.</div>" +
-		"Admittedly, this was not an extremely difficult producer-consumer pattern to exploit but you performed quite well nonetheless.",
-		[
-			new Thread([
-				createOuterWhile(),
-				new IfLongInstruction(new SemaphoreTryWaitExpression("ss"), "if"),
-				createDequeueUnsafe("queue"),
-				new ElseInstruction("if"),
-				new CommentInstruction("Nothing in the queue."),
-				new EndIfLongInstruction("if"),
-				createOuterWhileEnd()
-			]),
-			new Thread([
-				createOuterWhile(),
-				new SemaphoreReleaseInstruction("ss"),
-				createEnqueueUnsafe("queue", "new Dragon()"),
-				createOuterWhileEnd()
-			])
-		]
-		,
-		{
-			"ss" : {
-				name : "ss",
-				type : "System.Threading.SemaphoreSlim",
-				value : 0
-			},
-			"queue" : new QueueVariable("queue", "Dragon", 0)
-		}
-	),
-	"S3-producerConsumer" : new Level(
-		"S3-producerConsumer",
-		"Producer-Consumer (variant)",
-		"The victory conditions just keep coming!",
-		"<div class='story-intro'>Only one factory line remains. If you disrupt this, the entire land will be swept clean and the Empire will have lost all production.</div>" +
-		"For this challenge, it will be useful to know that most library methods are not thread-safe and if two threads enter an unsafe method on the same object simultaneously, strange things may happen. Things that result in your victory.",
-		"<div class='story-outro'>Congratulations, Scheduler! The Empire's economy is in shambles.</div>Are you ready for the next challenge?",
-		[
-			new Thread([
-				createOuterWhile(),
-				createEnqueueUnsafe("queue", "new Golem()"),
-				createOuterWhileEnd()
-			], "The Producer"),
-			new Thread([
-				createOuterWhile(),
-				new IfInstruction(new QueueNotEmptyExpression("queue"), "if"),
-				createDequeueUnsafe("queue"),
-				new EndIfInstruction("if"),
-				createOuterWhileEnd()
-			], "The Consumer")
-		],
-		{
-			"queue" : new QueueVariable("queue", "Golem", 0)
-		}
-	),
-	"CV1-simple": new Level(
-		"CV1-simple",
-		"Condition Variables",
-		"Don't worry. It's not <i>that</i> hard.",
-		"Condition variables are, unfortunately, still a rather difficult topic. We won't even try to get you a confusing story here, they're just hard. Try. If you fail, skip.",
-		"Your skill is unmatched, Master Scheduler! Truly no program is safe before you.",
-		[
-			new Thread([
-				createOuterWhile(),
-				new MonitorEnterInstruction("mutex"),
-				new IfInstruction(new QueueIsEmptyExpression("queue"), "if"),
-				createMonitorWait("mutex"),
-				new EndIfInstruction("if"),
-				createDequeueUnsafe("queue"),
-				new MonitorExitInstruction("mutex"),
-				createOuterWhileEnd()
-			]),
-			new Thread([
-				createOuterWhile(),
-				new MonitorEnterInstruction("mutex"),
-				new IfInstruction(new QueueIsEmptyExpression("queue"), "if"),
-				createMonitorWait("mutex"),
-				new EndIfInstruction("if"),
-				createDequeueUnsafe("queue"),
-				new MonitorExitInstruction("mutex"),
-				createOuterWhileEnd()
-			]),
-			new Thread([
-				createOuterWhile(),
-				new MonitorEnterInstruction("mutex"),
-				createEnqueueUnsafe("queue", 42),
-				new MonitorPulseAll("mutex"),
-				new MonitorExitInstruction("mutex"),
-				createOuterWhileEnd()
-			])
-		],
-		{
-			"mutex" : {
-				name : "mutex",
-				type : "System.Object",
-				value : "unimportant"
-			},
-			"queue" : new QueueVariable("queue", "int", 0)
-		}
-	)
+        }
+    ),
+    "L3-complexer": new Level(
+        "L3-complexer",
+        "A More Complex Thread",
+        "Three locks, two threads, one flag.",
+        "<span class='story-intro'>You look up the Refactor Lands hill at the lone flag that shows who controls this important territory. You climb fast - you must reach it first. Unfortunately, that won't happen - not one, not two, but three enemy armies are closing in on the hill and they will all reach the flag before you do. You must do something about this, stop them somehow, if you are to claim this territory and save the poor people of Refactor Lands the trouble of changing paradigms.</span><br><br>" +
+        "This may appear difficult at first. There's a lot of locks, a boolean flag and critical sections. The code is not very readable and an error could be anywhere. In fact, it wouldn't surprise us if you found a solution to this challenge different from what we thought of when creating it. You should definitely write more concise and understandable code than this.<br><br>" +
+        "Even so, you might use this advice: In C#, locks can be locked recursively. For example, a thread can <i>lock</i> (via <i>Monitor.Enter</i>) a single object multiple times. In order to release the lock on that object and permit other threads to lock it, <i>all</i> of the locks must be released, i.e. the method <i>Monitor.Exit</i> must be called the same number of times as <i>Monitor.Enter</i>.<br><br>" +
+        "You did not encounter <code><a href='https://msdn.microsoft.com/en-us/library/system.threading.monitor.tryenter'>Monitor.TryEnter()</a></code> yet. It does exactly what it says on the tin: it tries to lock a lock if possible. If the lock is unlocked, it locks it and returns <code>true</code>. Otherwise, the lock remains locked by its owner and the method returns <code>false</code>.<br><br>",
+        "<span class='story-outro'>You replace the neutral flag with the sign of the Sequentialists. You have won. Smiling, you look down from the hill at the three armies locked in place - neither able to move. Once again, you have proven the uselessness of parallelism.</span><br><br>The <b><a href='https://msdn.microsoft.com/en-us/library/system.threading.monitor.tryenter'>Monitor.TryEnter()</a></b> method, if successful, also locks the mutex and in C#, objects can be locked recursively. In order for a lock to be released, it must be <i>exited</i> the same number of times it was <i>entered</i>. In this game, you saw that there is no matching <i>Monitor.Exit()</i> call to the <i>.TryEnter()</i> call and thus the first thread was able to lock the object, recursively, many times, making it impossible for the second thread to lock it.",
+        [
+            new Thread([
+                createOuterWhile(),
+                new IfLongInstruction(new MonitorTryEnterExpression("mutex"), "if"),
+                new MonitorEnterInstruction("mutex3"),
+                new MonitorEnterInstruction("mutex"),
+                new CriticalSectionInstruction(),
+                new MonitorExitInstruction("mutex"),
+                new MonitorEnterInstruction("mutex2"),
+                createAssignment("flag", new LiteralExpression(false)),
+                new MonitorExitInstruction("mutex2"),
+                new MonitorExitInstruction("mutex3"),
+                new ElseInstruction("if"),
+                new MonitorEnterInstruction("mutex2"),
+                createAssignment("flag", new LiteralExpression(true)),
+                new MonitorExitInstruction("mutex2"),
+                new EndIfLongInstruction("if"),
+                createOuterWhileEnd()
+            ]),
+            new Thread([
+                createOuterWhile(),
+                new IfLongInstruction(new VariableExpression("flag"), "if"),
+                new MonitorEnterInstruction("mutex2"),
+                new MonitorEnterInstruction("mutex"),
+                createAssignment("flag", new LiteralExpression(false)),
+                new CriticalSectionInstruction(),
+                new MonitorExitInstruction("mutex"),
+                new MonitorEnterInstruction("mutex2"),
+                new ElseInstruction("if"),
+                new MonitorEnterInstruction("mutex"),
+                createAssignment("flag", new LiteralExpression(false)),
+                new MonitorExitInstruction("mutex"),
+                new EndIfLongInstruction("if"),
+                createOuterWhileEnd()
+            ])
+        ],
+        {
+            "mutex" : new ObjectVariable("mutex"),
+            "mutex2" : new ObjectVariable("mutex2"),
+            "mutex3" :  new ObjectVariable("mutex3"),
+            "flag":  {
+                name : "flag",
+                type : "System.Boolean",
+                value : false
+            }
+        }
+    ),
+    "S1-simple" : new Level(
+        "S1-simple",
+        "Semaphores",
+        "A semaphore is a simple synchronization primitive.",
+        "<div class='story-intro'>You behold the Factory Lands of the Deadlock Empire. You are almost in awe. Everything runs smoothly and efficiently, all factories producing new materials at the same time without unnecessary delays, everything manned by thousands of workers. Cooperation. But there are weaknesses - it may be efficient but it is unstable. A single mistake - anywhere - can bring entire factories down. You take one look at the fearsome mechanical dragons leaving the factories on numerous conveyor bolts and your determination is sealed. You will destroy this land.</div>" +
+        "<a href='https://msdn.microsoft.com/en-us/library/system.threading.semaphoreslim(v=vs.110).aspx'>Semaphores</a> limit the number of threads that can access a resource at the same time. In C#, they are implemented by the SemaphoreSlim class." +
+        "You can imagine a semaphore as a stack of coins. When a thread wants to access the resource protected by the semaphore, it needs to take a coin. Once it's done, it returns the coin to the stack.<br>" +
+        "To take a coin, you can call the <code><a href='https://msdn.microsoft.com/en-us/library/dd270787(v=vs.110).aspx'>Wait()</a></code> method on the semaphore. If there are no coins on the stack, the method waits until someone returns a coin. If you don't want to wait forever, you can pass it how long should it wait, in milliseconds. In that case, <code>Wait()</code> will return a boolean indicating whether it obtained a coin.<br>" +
+        "The <code><a href='https://msdn.microsoft.com/en-us/library/dd235727(v=vs.110).aspx'>Release()</a></code> method adds a coin on the stack. Normally, you would call <code>Release()</code> only after a <code>Wait()</code> - you would take a coin, do something while you have it, and then give it back. However, you can also call <code>Release()</code> while you don't have any coins yourself. If you let Thread 1 run, you will see it do this: if it can't find a coin within 500 milliseconds, it will create a new one.<br><br>" +
+        "The two threads below try to use a semaphore to ensure they don't enter the critical section at the same time. Can you figure out what are they doing wrong?",
+        "<div class='story-outro'>A few factories stopped but the Parallel Wizard is hard at work repairing them. You must move on and act quickly to capitalize on this.</div>",
+        [
+            new Thread([
+                createOuterWhile(),
+                new SemaphoreWaitInstruction("ss"),
+                new CriticalSectionInstruction(),
+                new SemaphoreReleaseInstruction("ss"),
+                createOuterWhileEnd()
+            ]),
+            new Thread([
+                createOuterWhile(),
+                new IfLongInstruction(new SemaphoreTryWaitExpression("ss"), "if"),
+                new CriticalSectionInstruction(),
+                new SemaphoreReleaseInstruction("ss"),
+                new ElseInstruction("if"),
+                new SemaphoreReleaseInstruction("ss"),
+                new EndIfLongInstruction("if"),
+                createOuterWhileEnd()
+            ])
+        ],
+        {
+            "ss" : new SemaphoreVariable("ss", 0)
+        }
+    ),
+    "S2-producerConsumer" : new Level(
+        "S2-producerConsumer",
+        "Producer-Consumer",
+        "A new victory condition awaits you!",
+        "<div class='story-intro'>You pick your target - one dragon-producing factory is sending its creations directly into an armory that outfits the machines with destructive weapons. If you disrupt this supply line, you will greatly reduce the number of dragons at the Empire's disposal.</div>" +
+        "In <a href='https://en.wikipedia.org/wiki/Producer–consumer_problem'>producer-consumer scenarios</a>, one thread produces some items that another thread consumes. " +
+        "For example, one thread could accept work requests from a user, and another thread could take outstanding requests and fulfill them.<br>" +
+        "Even through the producer-consumer problem might look trivial, it has some subtle complexity to it. For example, what if the consumer needs a lot of time to consume one item, while the producer produces items as fast as it can? We could run out of memory.<br>" +
+        'Semaphores are useful for producer-consumer problems. Remember the "coin stack" analogy: each item in the queue is represented by a coin; when the producer produces a new one, it adds a coin, and when the consumer consumes an item, it removes a coin.<br><br>' +
+        "In this challenge, your goal is cause an exception to be raised.<br>",
+        "<div class='story-outro'>Alarms sound over the lands but you hear only the sweet sound of victory. Soon, the Sequentialists will win and everything will happen in order, as was meant to be.</div>" +
+        "Admittedly, this was not an extremely difficult producer-consumer pattern to exploit but you performed quite well nonetheless.",
+        [
+            new Thread([
+                createOuterWhile(),
+                new IfLongInstruction(new SemaphoreTryWaitExpression("ss"), "if"),
+                createDequeueUnsafe("queue"),
+                new ElseInstruction("if"),
+                new CommentInstruction("Nothing in the queue."),
+                new EndIfLongInstruction("if"),
+                createOuterWhileEnd()
+            ]),
+            new Thread([
+                createOuterWhile(),
+                new SemaphoreReleaseInstruction("ss"),
+                createEnqueueUnsafe("queue", "new Dragon()"),
+                createOuterWhileEnd()
+            ])
+        ]
+        ,
+        {
+            "ss" : {
+                name : "ss",
+                type : "System.Threading.SemaphoreSlim",
+                value : 0
+            },
+            "queue" : new QueueVariable("queue", "Dragon", 0)
+        }
+    ),
+    "S3-producerConsumer" : new Level(
+        "S3-producerConsumer",
+        "Producer-Consumer (variant)",
+        "The victory conditions just keep coming!",
+        "<div class='story-intro'>Only one factory line remains. If you disrupt this, the entire land will be swept clean and the Empire will have lost all production.</div>" +
+        "For this challenge, it will be useful to know that most library methods are not thread-safe and if two threads enter an unsafe method on the same object simultaneously, strange things may happen. Things that result in your victory.",
+        "<div class='story-outro'>Congratulations, Scheduler! The Empire's economy is in shambles.</div>Are you ready for the next challenge?",
+        [
+            new Thread([
+                createOuterWhile(),
+                createEnqueueUnsafe("queue", "new Golem()"),
+                createOuterWhileEnd()
+            ], "The Producer"),
+            new Thread([
+                createOuterWhile(),
+                new IfInstruction(new QueueNotEmptyExpression("queue"), "if"),
+                createDequeueUnsafe("queue"),
+                new EndIfInstruction("if"),
+                createOuterWhileEnd()
+            ], "The Consumer")
+        ],
+        {
+            "queue" : new QueueVariable("queue", "Golem", 0)
+        }
+    ),
+    "CV1-simple": new Level(
+        "CV1-simple",
+        "Condition Variables",
+        "Don't worry. It's not <i>that</i> hard.",
+        "Condition variables are, unfortunately, still a rather difficult topic. We won't even try to get you a confusing story here, they're just hard. Try. If you fail, skip.",
+        "Your skill is unmatched, Master Scheduler! Truly no program is safe before you.",
+        [
+            new Thread([
+                createOuterWhile(),
+                new MonitorEnterInstruction("mutex"),
+                new IfInstruction(new QueueIsEmptyExpression("queue"), "if"),
+                createMonitorWait("mutex"),
+                new EndIfInstruction("if"),
+                createDequeueUnsafe("queue"),
+                new MonitorExitInstruction("mutex"),
+                createOuterWhileEnd()
+            ]),
+            new Thread([
+                createOuterWhile(),
+                new MonitorEnterInstruction("mutex"),
+                new IfInstruction(new QueueIsEmptyExpression("queue"), "if"),
+                createMonitorWait("mutex"),
+                new EndIfInstruction("if"),
+                createDequeueUnsafe("queue"),
+                new MonitorExitInstruction("mutex"),
+                createOuterWhileEnd()
+            ]),
+            new Thread([
+                createOuterWhile(),
+                new MonitorEnterInstruction("mutex"),
+                createEnqueueUnsafe("queue", 42),
+                new MonitorPulseAll("mutex"),
+                new MonitorExitInstruction("mutex"),
+                createOuterWhileEnd()
+            ])
+        ],
+        {
+            "mutex" : {
+                name : "mutex",
+                type : "System.Object",
+                value : "unimportant"
+            },
+            "queue" : new QueueVariable("queue", "int", 0)
+        }
+    )
 };

--- a/js/content/levels.js
+++ b/js/content/levels.js
@@ -13,7 +13,7 @@ var levels = {
                     new LiteralExpression(2))),
                 new IfInstruction(new EqualityExpression(new VariableExpression("a"), new LiteralExpression(3)), "if"),
                 new FailureInstruction(),
-                new EndIfInstruction("}", "if")
+                new EndIfInstruction("if")
             ])
         ],
         {
@@ -140,8 +140,9 @@ var levels = {
                     new OrExpression(
                         new EqualityExpression(new VariableExpression("turn"), new LiteralExpression(2)),
                         new EqualityExpression(new VariableExpression("turn"), new LiteralExpression(3))
-                    )
-                ), "wait", "while ((flag2 || flag3) &&\n         (turn == 2 || turn == 3)) {"),
+                    ),
+                    "\n         "
+                ), "wait"),
                 new EmptyStatement(),
                 new EndWhileInstruction("wait"),
                 new CriticalSectionInstruction(),
@@ -161,8 +162,9 @@ var levels = {
                     new OrExpression(
                         new EqualityExpression(new VariableExpression("turn"), new LiteralExpression(1)),
                         new EqualityExpression(new VariableExpression("turn"), new LiteralExpression(3))
-                    )
-                ), "wait", "while ((flag1 || flag3) &&\n         (turn == 1 || turn == 3)) {"),
+                    ),
+                    "\n         "
+                ), "wait"),
                 new EmptyStatement(),
                 new EndWhileInstruction("wait"),
                 new CriticalSectionInstruction(),
@@ -182,8 +184,9 @@ var levels = {
                     new OrExpression(
                         new EqualityExpression(new VariableExpression("turn"), new LiteralExpression(2)),
                         new EqualityExpression(new VariableExpression("turn"), new LiteralExpression(1))
-                    )
-                ), "wait", "while ((flag2 || flag1) &&\n         (turn == 2 || turn == 1)) {"),
+                    ),
+                    "\n         "
+                ), "wait"),
                 new EmptyStatement(),
                 new EndWhileInstruction("wait"),
                 new CriticalSectionInstruction(),
@@ -336,24 +339,24 @@ var levels = {
         [
             new Thread([
                 createOuterWhile(),
-                new SemaphoreWaitInstruction("ss"),
+                new SemaphoreWaitInstruction("semaphore"),
                 new CriticalSectionInstruction(),
-                new SemaphoreReleaseInstruction("ss"),
+                new SemaphoreReleaseInstruction("semaphore"),
                 createOuterWhileEnd()
             ]),
             new Thread([
                 createOuterWhile(),
-                new IfLongInstruction(new SemaphoreTryWaitExpression("ss"), "if"),
+                new IfLongInstruction(new SemaphoreTryWaitExpression("semaphore"), "if"),
                 new CriticalSectionInstruction(),
-                new SemaphoreReleaseInstruction("ss"),
+                new SemaphoreReleaseInstruction("semaphore"),
                 new ElseInstruction("if"),
-                new SemaphoreReleaseInstruction("ss"),
+                new SemaphoreReleaseInstruction("semaphore"),
                 new EndIfLongInstruction("if"),
                 createOuterWhileEnd()
             ])
         ],
         {
-            "ss" : new SemaphoreVariable("ss", 0)
+            "semaphore" : new SemaphoreVariable("semaphore", 0)
         }
     ),
     "S2-producerConsumer" : new Level(
@@ -371,7 +374,7 @@ var levels = {
         [
             new Thread([
                 createOuterWhile(),
-                new IfLongInstruction(new SemaphoreTryWaitExpression("ss"), "if"),
+                new IfLongInstruction(new SemaphoreTryWaitExpression("semaphore"), "if"),
                 createDequeueUnsafe("queue"),
                 new ElseInstruction("if"),
                 new CommentInstruction("Nothing in the queue."),
@@ -380,14 +383,14 @@ var levels = {
             ]),
             new Thread([
                 createOuterWhile(),
-                new SemaphoreReleaseInstruction("ss"),
-                createEnqueueUnsafe("queue", "new Dragon()"),
+                new SemaphoreReleaseInstruction("semaphore"),
+                createEnqueueUnsafe("queue", LanguageDependentConstruction("Dragon")),
                 createOuterWhileEnd()
             ])
         ]
         ,
         {
-            "ss" : new ManualResetEventVariable("ss", 0),
+            "semaphore" : new ManualResetEventVariable("semaphore", 0),
             "queue" : new QueueVariable("queue", new ObjectType("Dragon"), 0)
         }
     ),
@@ -401,7 +404,7 @@ var levels = {
         [
             new Thread([
                 createOuterWhile(),
-                createEnqueueUnsafe("queue", "new Golem()"),
+                createEnqueueUnsafe("queue", LanguageDependentConstruction("Golem")),
                 createOuterWhileEnd()
             ], "The Producer"),
             new Thread([

--- a/js/content/tutorial.js
+++ b/js/content/tutorial.js
@@ -19,11 +19,7 @@ levels["T1-Interface"] = new Level("T1-Interface",
         ])
     ],
     {
-        "flag" : {
-            name : "flag",
-            type : "System.Boolean",
-            value : true
-        }
+        "flag" : new BooleanVariable("flag", true)
     }
 );
 var loadTutorial1 = function() {
@@ -68,10 +64,6 @@ levels["T2-Expansion"] = new Level("T2-Expansion",
         ])
     ],
     {
-        "a" : {
-            name : "a",
-            type : "System.Int32",
-            value : 0
-        }
+        "a" : new IntegerVariable("a", 0)
     }
 );

--- a/js/expression.js
+++ b/js/expression.js
@@ -1,82 +1,72 @@
 var LiteralExpression = function(value) {
-    this.evaluate = function() { return value; };
-    if ((value === false) || (value === true)) {
-	    this.code = "<span class='keyword'>" + value.toString() + "</span>";
-    } else {
-	    this.code = value.toString();
-    }
+    this.evaluate = function() {
+        return value;
+    };
+    this.code = LanguageDependentLiteralExpression(value);
 };
 var VariableExpression = function(name) {
-    this.evaluate = function(threadState, globalState) { return globalState[name].value; };
-    this.code = name;
+    this.evaluate = function(threadState, globalState) {
+        return globalState[name].value;
+    };
+    this.code = LanguageDependentIdentifierCapitalisation(name);
 };
-var AdditionExpression = function(left, right) {
-    this.evaluate = function(threadState, globalState) { return left.evaluate(threadState, globalState) +
-            right.evaluate(threadState, globalState); };
-    this.code = left.code + " + " + right.code;
+var AdditionExpression = function(left, right, separator) {
+    this.evaluate = function(threadState, globalState) {
+        return left.evaluate(threadState, globalState) + right.evaluate(threadState, globalState);
+    };
+    this.code = BinaryOperatorCode(left.code, right.code, "+", separator);
 };
-var ModuloExpression = function (left, right) {
+var ModuloExpression = function (left, right, separator) {
     this.evaluate = function (threadState, globalState) {
-        return left.evaluate(threadState, globalState) %
-            right.evaluate(threadState, globalState);
+        return left.evaluate(threadState, globalState) %  right.evaluate(threadState, globalState);
     };
-    this.code = left.code + " % " + right.code;
+    this.code = BinaryOperatorCode(left.code, right.code, LanguageDependentIntegerModulusOperator(), separator);
 };
-var SubtractionExpression = function(left, right) {
-    this.evaluate = function(threadState, globalState) { return left.evaluate(threadState, globalState) -
-        right.evaluate(threadState, globalState); };
-    this.code = left.code + " - " + right.code;
+var SubtractionExpression = function(left, right, separator) {
+    this.evaluate = function(threadState, globalState) {
+        return left.evaluate(threadState, globalState) - right.evaluate(threadState, globalState);
+    };
+    this.code = BinaryOperatorCode(left.code, right.code, "-", separator);
 };
-var EqualityExpression =
-    function (left, right) {
-        this.evaluate = function(threadState, globalState)  {
-            return left.evaluate(threadState, globalState) == right.evaluate(threadState, globalState);
-        };
-        this.code = left.code + " == " + right.code;
-
+var EqualityExpression = function (left, right, separator) {
+    this.evaluate = function(threadState, globalState)  {
+        return left.evaluate(threadState, globalState) == right.evaluate(threadState, globalState);
     };
-var LessThanExpression =
-    function (left, right) {
-        this.evaluate = function(threadState, globalState)  {
-            return left.evaluate(threadState, globalState) < right.evaluate(threadState, globalState);
-        };
-        this.code = left.code + " < " + right.code;
-
+    this.code = BinaryOperatorCode(left.code, right.code, LanguageDependentValueEqualityOperator(), separator);
+};
+var LessThanExpression = function (left, right, separator) {
+    this.evaluate = function(threadState, globalState)  {
+        return left.evaluate(threadState, globalState) < right.evaluate(threadState, globalState);
     };
-var AndExpression =
-    function (left, right) {
-        this.evaluate = function(threadState, globalState)  {
-            return left.evaluate(threadState, globalState) && right.evaluate(threadState, globalState);
-        };
-        this.code = left.code + " && " + right.code;
+    this.code = BinaryOperatorCode(left.code, right.code, "<", separator);
+};
+var AndExpression = function (left, right, separator) {
+    this.evaluate = function(threadState, globalState)  {
+        return left.evaluate(threadState, globalState) && right.evaluate(threadState, globalState);
     };
-var OrExpression =
-    function (left, right) {
-        this.evaluate = function(threadState, globalState)  {
-            return left.evaluate(threadState, globalState) || right.evaluate(threadState, globalState);
-        };
-        this.code = left.code + " || " + right.code;
+    this.code = LanguageDependentAndOperatorCode(left.code, right.code, separator);
+};
+var OrExpression = function (left, right, separator) {
+    this.evaluate = function(threadState, globalState)  {
+        return left.evaluate(threadState, globalState) || right.evaluate(threadState, globalState);
     };
-var InequalityExpression =
-    function (left, right) {
-        this.evaluate = function(threadState, globalState)  {
-            return left.evaluate(threadState, globalState) != right.evaluate(threadState, globalState);
-        };
-        this.code = left.code + " != " + right.code;
-
+    this.code = BinaryOperatorCode(left.code, right.code, LanguageDependentBooleanOrOperator(), separator);
+};
+var InequalityExpression = function (left, right, separator) {
+    this.evaluate = function(threadState, globalState)  {
+        return left.evaluate(threadState, globalState) != right.evaluate(threadState, globalState);
     };
-var GreaterThanExpression =
-    function (left, right) {
-        this.evaluate = function(threadState, globalState)  {
-            return left.evaluate(threadState, globalState) > right.evaluate(threadState, globalState);
-        };
-        this.code = left.code + " > " + right.code;
+    this.code = BinaryOperatorCode(left.code, right.code, LanguageDependentValueInequalityOperator(), separator);
+};
+var GreaterThanExpression = function (left, right, separator) {
+    this.evaluate = function(threadState, globalState)  {
+        return left.evaluate(threadState, globalState) > right.evaluate(threadState, globalState);
     };
-var GreaterOrEqualExpression =
-    function (left, right) {
-        this.evaluate = function(threadState, globalState)  {
-            return left.evaluate(threadState, globalState) >= right.evaluate(threadState, globalState);
-        };
-        this.code = left.code + " >= " + right.code;
-
+    this.code = BinaryOperatorCode(left.code, right.code, ">", separator);
+};
+var GreaterOrEqualExpression = function (left, right, separator) {
+    this.evaluate = function(threadState, globalState)  {
+        return left.evaluate(threadState, globalState) >= right.evaluate(threadState, globalState);
     };
+    this.code = BinaryOperatorCode(left.code, right.code, ">=", separator);
+};

--- a/js/instructions/instructions-high-level-synchronization.js
+++ b/js/instructions/instructions-high-level-synchronization.js
@@ -1,5 +1,5 @@
 var ManualResetEventSet = function(name) {
-    this.code = name + ".Set();";
+    this.code = instructionCode(instanceMethodExpressionCode(name, "Set"));
     this.tooltip = "Atomic. Sets the state of the ManualResetEventSlim to \"signaled\" which causes its Wait() method to no longer be blocking.";
     this.execute = function(threadState, globalState) {
         var mres = globalState[name];
@@ -8,7 +8,7 @@ var ManualResetEventSet = function(name) {
     }
 };
 var ManualResetEventReset = function(name) {
-    this.code = name + ".Reset();";
+    this.code = instructionCode(instanceMethodExpressionCode(name, "Reset"));
     this.tooltip = "Atomic. Sets the state of the ManualResetEventSlim to \"nonsignaled\" which causes its Wait() method to become blocking.";
     this.execute = function(threadState, globalState) {
         var mres = globalState[name];
@@ -17,12 +17,12 @@ var ManualResetEventReset = function(name) {
     }
 };
 var ManualResetEventWait = function(name) {
-    this.code = name + ".Wait();";
+    this.code = instructionCode(instanceMethodExpressionCode(name, "Wait"));
     this.tooltip = "Atomic. Blocks until the ManualResetEventSlim's state is set to 'signaled'.";
     this.isBlocking = function(threadState, globalState) {
         var mres = globalState[name];
         if (!mres.value) {
-            return "Waiting for signal (<code>" + name + ".Set()</code>)";
+            return "Waiting for signal (<code>" + LanguageDependentIdentifierCapitalisation(name) + ".Set()</code>)";
         }
         return false;
     };
@@ -31,7 +31,7 @@ var ManualResetEventWait = function(name) {
     }
 };
 var CountdownEventSignal = function(name) {
-    this.code = name + ".Signal();";
+    this.code = instructionCode(instanceMethodExpressionCode(name, "Signal"));
     this.tooltip = "Atomic. Decrements the CountdownEvent's countdown timer by one. Throws an exception if the timer is already at zero.";
     this.execute = function(threadState, globalState) {
         var mres = globalState[name];
@@ -44,14 +44,14 @@ var CountdownEventSignal = function(name) {
     }
 };
 var CountdownEventWait = function(name) {
-    this.code = name + ".Wait();";
+    this.code = instructionCode(instanceMethodExpressionCode(name, "Wait"));
     this.tooltip = "Atomic. Blocks until the CountdownEvent's countdown timer reaches zero.";
     this.isBlocking = function(threadState, globalState) {
         var mres = globalState[name];
-	if (mres.value == 0) {
-		return false;
-	}
-	return "Waiting until <code>" + name + "</code> counts down to zero.";
+        if (mres.value == 0) {
+            return false;
+        }
+        return "Waiting until <code>" + LanguageDependentIdentifierCapitalisation(name) + "</code> counts down to zero.";
     };
     this.execute = function(threadState, globalState) {
         moveToNextInstruction(threadState);
@@ -59,7 +59,7 @@ var CountdownEventWait = function(name) {
 };
 
 var BarrierSignalAndWait = function(name) {
-    this.code = name + ".SignalAndWait();";
+    this.code = instructionCode(instanceMethodExpressionCode(name, "SignalAndWait"));
     this.tooltip = "Atomic! Blocks until all threads in arrive at the barrier, then enters a new phase - its counter is reset back to the initial number of participants.";
     this.isBlocking = function(threadState, globalState) {
         var barrier = globalState[name];

--- a/js/instructions/instructions-queue.js
+++ b/js/instructions/instructions-queue.js
@@ -33,7 +33,8 @@ var MinorDequeue = function(queue) {
     };
 };
 var QueueNotEmptyExpression = function(queue) {
-    this.code = queue + ".Count > 0";
+    var expression = new GreaterThanExpression(new VariableExpression(instanceMemberExpressionCode(queue, "Count")), new LiteralExpression(0));
+    this.code = expression.code;
     this.tooltip = "Returns true if the queue is not empty.";
     this.evaluate = function (threadState, globalState) {
       if (globalState[queue].value > 0) {
@@ -44,7 +45,8 @@ var QueueNotEmptyExpression = function(queue) {
     };
 };
 var QueueIsEmptyExpression = function(queue) {
-    this.code = queue + ".Count == 0";
+    var expression = new EqualityExpression(new VariableExpression(instanceMemberExpressionCode(queue, "Count")), new LiteralExpression(0));
+    this.code = expression.code;
     this.tooltip = "Returns true if the queue is empty.";
     this.evaluate = function (threadState, globalState) {
         if (globalState[queue].value == 0) {
@@ -62,13 +64,14 @@ var MinorBecomesConsistent = function(queue) {
         moveToNextInstruction(threadState);
     };
 };
-var createEnqueueUnsafe = function(queue, number) {
+var createEnqueueUnsafe = function(queue, item) {
     var minorInstructions = [
         new MinorBecomesInconsistent(queue),
         new MinorEnqueue(queue),
         new MinorBecomesConsistent(queue)
     ];
-    var v = new ExpandableInstruction(queue + ".Enqueue(" + number + ");", minorInstructions);
+
+    var v = new ExpandableInstruction(instanceMethodExpressionCode(queue, "Enqueue", item), minorInstructions);
     v.tooltip = "[Expandable] Adds an object to the end of the queue. This operation is not atomic nor thread-safe.";
     return v;
 };
@@ -78,7 +81,7 @@ var createDequeueUnsafe = function(queue) {
         new MinorDequeue(queue),
         new MinorBecomesConsistent(queue)
     ];
-    var v = new ExpandableInstruction(queue + ".Dequeue();", minorInstructions);
+    var v = new ExpandableInstruction(instanceMethodExpressionCode(queue, "Dequeue"), minorInstructions);
     v.tooltip = "[Expandable] Removes an object from the front of the queue. Raises an exception if the queue is empty. This operation is not atomic nor thread-safe.";
     return v;
 };

--- a/js/instructions/instructions-synchronization.js
+++ b/js/instructions/instructions-synchronization.js
@@ -1,11 +1,23 @@
+var staticCode = function(identifier) {
+    return spanTag("static", identifier);
+};
+
+var staticMethodExpressionCode = function(className, methodName, parameters) {
+    return dereferenceMemberCode(staticCode(className), methodName) + ParenthesisedExpressionCode(parameters);
+};
+
+var staticMonitorMethodExpressionCode = function(methodName, monitorName) {
+    return staticMethodExpressionCode("Monitor", methodName, LanguageDependentIdentifierCapitalisation(monitorName));
+};
+
 var MonitorEnterInstruction = function(monitorName) {
-    this.code = "<span class='static'>Monitor</span>.Enter(" + monitorName + ");";
+    this.code = instructionCode(staticMonitorMethodExpressionCode("Enter", monitorName));
     this.tooltip = "Atomic. Acquires a lock. If this thread already owns this lock, the lock counter is incremented. If another thread currently owns this lock, this call blocks until the lock is released.";
     this.isBlocking = function(threadState, globalState) {
         var monitor = globalState[monitorName];
         if (monitor.lastLockedByThread != null &&
             monitor.lastLockedByThread != threadState.id) {
-            return "Waiting for " + gameState.getLevel().getThreadName(monitor.lastLockedByThread) + " to unlock <code>" + monitorName + "</code>.";
+            return "Waiting for " + gameState.getLevel().getThreadName(monitor.lastLockedByThread) + " to unlock <code>" + LanguageDependentIdentifierCapitalisation(monitorName) + "</code>.";
         } else {
             return false;
         }
@@ -30,7 +42,7 @@ var MonitorEnterInstruction = function(monitorName) {
     }
 };
 var MonitorTryEnterExpression = function (monitorName) {
-    this.code = "<span class='static'>Monitor</span>.TryEnter(" + monitorName + ")";
+    this.code = staticMonitorMethodExpressionCode("TryEnter", monitorName);
     this.tooltip = "Atomic. Checks whether the current thread can lock the specified object. If yes, it locks the object and returns true. If no, returns false.";
     this.evaluate = function(threadState, globalState) {
         var monitor = globalState[monitorName];
@@ -52,7 +64,7 @@ var MonitorTryEnterExpression = function (monitorName) {
     }
 };
 var MonitorExitInstruction = function(monitorName) {
-    this.code = "<span class='static'>Monitor</span>.Exit(" + monitorName + ");";
+    this.code = instructionCode(staticMonitorMethodExpressionCode("Exit", monitorName));
     this.tooltip = "Atomic. Releases a lock. If this thread had this locked multiple times, decrements the counter once  only. If this thread does not own this lock, an exception is thrown (and you win the level).";
     this.execute = function(threadState, globalState) {
         var monitor = globalState[monitorName];
@@ -72,7 +84,7 @@ var MonitorExitInstruction = function(monitorName) {
     }
 };
 var SemaphoreTryWaitExpression = function(semaphoreName) {
-    this.code = semaphoreName + ".Wait(500)";
+    this.code = instanceMethodExpressionCode(semaphoreName, "Wait", 500);
     this.tooltip = "Blocks the thread until the semaphore has a positive value or the specified timeout elapses. In the first case, it decrements the semaphore and returns true. In the second case, it returns false.<br><br>In this game, you can always step through this expression. What happens will be determined by whether the semaphore currently has a positive value.";
     this.evaluate = function(threadState, globalState) {
         if (globalState[semaphoreName].value > 0) {
@@ -85,13 +97,13 @@ var SemaphoreTryWaitExpression = function(semaphoreName) {
     }
 };
 var SemaphoreWaitInstruction = function(semaphoreName) {
-    this.code = semaphoreName + ".Wait();";
+    this.code = instructionCode(instanceMethodExpressionCode(semaphoreName, "Wait"));
     this.tooltip = "Atomic. Attempts to decrease the semaphore counter by one. If the semaphore is already at 0, this call blocks until another thread increases the counter by calling Release().";
     this.isBlocking = function (threadState, globalState) {
         if (globalState[semaphoreName].value > 0) {
             return false;
         } else {
-            return "Waiting for another thread to call <code>" + semaphoreName + ".Release()</code>.";
+            return "Waiting for another thread to call <code>" + LanguageDependentIdentifierCapitalisation(semaphoreName) + ".Release()</code>.";
         }
     };
     this.execute = function(threadState, globalState) {
@@ -106,7 +118,7 @@ var SemaphoreWaitInstruction = function(semaphoreName) {
 };
 
 var SemaphoreReleaseInstruction = function(semaphoreName) {
-    this.code = semaphoreName + ".Release();";
+    this.code = instructionCode(instanceMethodExpressionCode(semaphoreName, "Release"));
     this.tooltip = "Atomic. Increments the semaphore counter by one.";
     this.execute = function(threadState, globalState) {
         globalState[semaphoreName].value ++;
@@ -140,11 +152,11 @@ var MinorAwaitWakeUp = function(mutex) {
     this.code = "wait until woken up";
     this.execute = function(threadState) { moveToNextInstruction(threadState); };
     this.isBlocking = function(threadState) {
-	    if (!threadState.asleep) {
-		    return false;
-	    } else {
-		    return "Waiting for pulse on <code>" + mutex + "</code>.";
-	    }
+        if (!threadState.asleep) {
+            return false;
+        } else {
+            return "Waiting for pulse on <code>" + LanguageDependentIdentifierCapitalisation(mutex) + "</code>.";
+        }
     };
     this.tooltip = "This thread won't receive priority until it is woken up by a pulse. When the pulse arrives, you may step forwards as normal.";
 };
@@ -153,7 +165,7 @@ var MinorInternalMonitorEnter = function(mutex) {
         var monitor = globalState[mutex];
         if (monitor.lastLockedByThread != null &&
             monitor.lastLockedByThread != threadState.id) {
-            return "Waiting for " + gameState.getLevel().getThreadName(monitor.lastLockedByThread) + " to unlock <code>" + mutex + "</code>.";
+            return "Waiting for " + gameState.getLevel().getThreadName(monitor.lastLockedByThread) + " to unlock <code>" + LanguageDependentIdentifierCapitalisation(mutex) + "</code>.";
         } else {
             return false;
         }
@@ -164,7 +176,7 @@ var MinorInternalMonitorEnter = function(mutex) {
         monitor.lockCount = 1;
         moveToNextInstruction(threadState);
     };
-    this.code = "Monitor.Enter(" + mutex + ");";
+    this.code = instructionCode(staticMonitorMethodExpressionCode("Enter", mutex));
     this.tooltip = "This thread won't receive priority until it can reacquire the lock.";
 };
 var createMonitorWait = function(mutex) {
@@ -173,12 +185,12 @@ var createMonitorWait = function(mutex) {
         new MinorAwaitWakeUp(mutex),
         new MinorInternalMonitorEnter(mutex)
     ];
-    var v = new ExpandableInstruction("<span class='static'>Monitor</span>.Wait(" + mutex + ");", minorInstructions);
+    var v = new ExpandableInstruction(staticMonitorMethodExpressionCode("Wait", mutex), minorInstructions);
     v.tooltip = "[Expandable] Releases the lock and puts the thread to sleep until it is woken up by a pulse.";
     return v;
 };
 var MonitorPulse = function(mutex) {
-    this.code = "<span class='static'>Monitor</span>.Pulse(" + mutex + ");";
+    this.code = instructionCode(staticMonitorMethodExpressionCode("Pulse", mutex));
     this.tooltip = "Sends a wake-up signal to a random thread waiting on the specified mutex, if any.";
     this.execute = function (threadState, globalState) {
         var monitor = globalState[mutex];
@@ -200,7 +212,7 @@ var MonitorPulse = function(mutex) {
     };
 };
 var MonitorPulseAll = function(mutex) {
-    this.code = "<span class='static'>Monitor</span>.PulseAll(" + mutex + ");";
+    this.code = instructionCode(staticMonitorMethodExpressionCode("PulseAll", mutex));
     this.tooltip = "Sends a wake-up signal to all threads waiting on the specified mutex, if any.";
     this.execute = function (threadState, globalState) {
         var monitor = globalState[mutex];
@@ -220,11 +232,13 @@ var MonitorPulseAll = function(mutex) {
     };
 };
 var InterlockedIncrement = function(name) {
-    this.code =  "<span class='static'>Interlocked</span>.Increment(<span class='keyword'>ref</span> " + name + ");";
+    var expression = LanguageDependentInterlockedIncrement(name);
+    this.code = instructionCode(expression);
+
+
     this.tooltip = "Atomic. Atomically increments the variable by 1.";
     this.execute = function (threadState, globalState) {
         globalState[name].value++;
         moveToNextInstruction(threadState);
     }
 };
-

--- a/js/instructions/instructions.js
+++ b/js/instructions/instructions.js
@@ -1,30 +1,69 @@
-var moveToNextInstruction = function(threadState) {
-	if (threadState.expanded) {
-		threadState.programCounter[1]++;
+var dereferenceMemberCode = function(instanceOrClassCode, memberName) {
+    var capitalisedMemberName = LanguageDependentIdentifierCapitalisation(memberName);
+    if (instanceOrClassCode) {
+        return instanceOrClassCode + "." + capitalisedMemberName;
+    } else {
+        return capitalisedMemberName;
+    }
+}
 
-		var program = gameState.getProgramOfThread(threadState.id);
-		if (threadState.programCounter[1] >= program[threadState.programCounter[0]].minorInstructions.length) {
-			threadState.expanded = false;
-			threadState.programCounter[0]++;
-			threadState.programCounter[1] = 0;
-		}
-	} else {
-		threadState.expanded = false;
-		threadState.programCounter[0]++;
-		threadState.programCounter[1] = 0;
-	}
+var instanceMemberExpressionCode = function(instanceName, memberName) {
+    var capitalisedMemberName = LanguageDependentIdentifierCapitalisation(memberName);
+    if (instanceName) {
+        return dereferenceMemberCode(LanguageDependentIdentifierCapitalisation(instanceName), capitalisedMemberName)
+    } else {
+        return dereferenceMemberCode(instanceName, capitalisedMemberName)
+    }
+};
+
+var instanceMethodExpressionCode = function(instanceName, methodName, parameter, spanTagName) {
+    var parameterValue;
+    // falsify exccept values we're interested in: false, 0
+    if ((parameter) || (parameter === false) || (parameter === 0)) {
+        var expression = new LiteralExpression(parameter);
+        parameterValue = expression.code;
+    }
+    else {
+        parameterValue = "";
+    }
+    var expression = instanceMemberExpressionCode(instanceName, methodName);
+    if (spanTagName) {
+        expression = spanTag(spanTagName, expression);
+    }
+    return expression + ParenthesisedExpressionCode(parameterValue);
+};
+
+var instructionCode = function(expression) {
+    return expression + ";";
+};
+
+var moveToNextInstruction = function(threadState) {
+    if (threadState.expanded) {
+        threadState.programCounter[1]++;
+
+        var program = gameState.getProgramOfThread(threadState.id);
+        if (threadState.programCounter[1] >= program[threadState.programCounter[0]].minorInstructions.length) {
+            threadState.expanded = false;
+            threadState.programCounter[0]++;
+            threadState.programCounter[1] = 0;
+        }
+    } else {
+        threadState.expanded = false;
+        threadState.programCounter[0]++;
+        threadState.programCounter[1] = 0;
+    }
 };
 
 var goToInstruction = function(threadState, line) {
-	threadState.programCounter = [line, 0];
+    threadState.programCounter = [line, 0];
 };
 
 var Instruction = function(code) {
-	this.code = code;
-	this.tooltip = "This statement does nothing and merely fills up space.";
-	this.execute = function(threadState, globalState) {
-		moveToNextInstruction(threadState);
-	};
+    this.code = code;
+    this.tooltip = "This statement does nothing and merely fills up space.";
+    this.execute = function(threadState, globalState) {
+        moveToNextInstruction(threadState);
+    };
 };
 
 /**
@@ -37,231 +76,237 @@ var Instruction = function(code) {
  */
 
 var FlavorInstruction = function(flavorText) {
-	this.code = "<i>" + flavorText + "</i>;";
-	this.tooltip = "This statement does nothing. It is part of the business logic and does not affect parallelism. You may consider it thread-safe.";
-	this.execute = function(threadState, globalState) {
-		moveToNextInstruction(threadState);
-	};
+    this.code = "<i>" + LanguageDependentIdentifierCapitalisation(flavorText) + "</i>;";
+    this.tooltip = "This statement does nothing. It is part of the business logic and does not affect parallelism. You may consider it thread-safe.";
+    this.execute = function(threadState, globalState) {
+        moveToNextInstruction(threadState);
+    };
 };
 var GameOverInstruction = function() {
-	this.code = "<span class='game-over-instruction'>Environment.Exit(0);</span>";
-	this.tooltip = "If the program reaches this statement, then it's considered to have succeeded and you, as the player, lose this level, and will need to undo or reset.";
-	this.execute = function (threadState) {
-		lose("The program finished successfully by reaching <code>Environment.Exit(0)</code>. To conquer this challenge, don't let it happen.");
-	};
-	this.isBlocking = function() {
-		if (levelWasCleared) {
-			return "Program successfully exited.";
-		}
-		return false;
-	};
+//    this.code = instructionCode(spanTag("game-over-instruction", instanceMethodExpressionCode("Environment", "Exit", 0))); // semicolon would be outside span
+    this.code = spanTag("game-over-instruction", instructionCode(instanceMethodExpressionCode("Environment", "Exit", 0))); // semicolon inside span
+    this.tooltip = "If the program reaches this statement, then it's considered to have succeeded and you, as the player, lose this level, and will need to undo or reset.";
+    this.execute = function (threadState) {
+        lose("The program finished successfully by reaching <code>Environment.Exit(0)</code>. To conquer this challenge, don't let it happen.");
+    };
+    this.isBlocking = function() {
+        if (levelWasCleared) {
+            return "Program successfully exited.";
+        }
+        return false;
+    };
 };
 var FailureInstruction = function() {
-	this.code = "<span class='failure-statement'>Debug.Assert(false)</span>;";
-	this.tooltip = "If you execute this statement, you will win this level.";
-	this.execute = function(threadState, globalState) {
-		win("You executed a failure instruction.");
-	};
-	this.isBlocking = function() {
-		if (levelWasCleared) {
-			return "Execution failed.";
-		}
-		return false;
-	};
+//    this.code = instructionCode(instanceMethodExpressionCode(LanguageDependentDebugInstanceName(), "Assert", false, "failure-statement")); // parenthesis and parameter would be outside the span
+    this.code = instructionCode(spanTag("failure-statement", instanceMethodExpressionCode(LanguageDependentDebugInstanceName(), "Assert", false))); // everything but semicolon inside span
+    this.tooltip = "If you execute this statement, you will win this level.";
+    this.execute = function(threadState, globalState) {
+        win("You executed a failure instruction.");
+    };
+    this.isBlocking = function() {
+        if (levelWasCleared) {
+            return "Execution failed.";
+        }
+        return false;
+    };
 };
 
 var CriticalSectionInstruction = function() {
-	this.isCriticalSection = true;
-	this.code = "<span class='critical-section'>critical_section</span>();";
-	this.tooltip = "If two threads are about to execute a Critical Section Instruction at the same time, you win the level.";
-	this.execute = function (threadState, globalState) {
-		moveToNextInstruction(threadState);
-	};
+    this.isCriticalSection = true;
+    this.code = instructionCode(instanceMethodExpressionCode("", "critical_section", null, "critical-section"));
+    this.tooltip = "If two threads are about to execute a Critical Section Instruction at the same time, you win the level.";
+    this.execute = function (threadState, globalState) {
+        moveToNextInstruction(threadState);
+    };
 };
 
 var findMatchingInstructionIndex = function(program, name, type) {
-	for (var i = 0; i < program.length; i++) {
-		var instruction = program[i];
-		if ((instruction instanceof type) && instruction.name == name) {
-			return i;
-		}
-	}
-	fail("Failed to find matching instruction", program, name, type);
-	return 0;
+    for (var i = 0; i < program.length; i++) {
+        var instruction = program[i];
+        if ((instruction instanceof type) && instruction.name == name) {
+            return i;
+        }
+    }
+    fail("Failed to find matching instruction", program, name, type);
+    return 0;
 };
 
 var IfInstruction = function(expression, name) {
-	this.code = "<span class='keyword'>if</span> (" + expression.code + ") {";
-	this.name = name;
-	this.tooltip = "The \"if\" statement evaluates an expression. If it's true, the specified statements are executed. Otherwise, they are skipped.";
-	if (expression.tooltip) {
-		this.tooltip += "<br><br><b>Expression:</b><br>" + expression.tooltip;
-	}
-	this.isBlocking = function(threadState, globalState) {
-		return (expression.isBlocking && expression.isBlocking(threadState, globalState));
-	};
-	this.execute = function(threadState, globalState, threadProgram) {
-		if (expression.evaluate(threadState, globalState)) {
-			moveToNextInstruction(threadState);  // goto true branch
-		} else {
-			// Condition is false, jump to matching EndIf.
-			var matchingEndIf = findMatchingInstructionIndex(threadProgram, name, EndIfInstruction);
-			goToInstruction(threadState, matchingEndIf);
-		}
-	};
+    this.code = LanguageDependentIf() + LanguageDependentIfWhileDoExpression(expression.code) + LanguageDependentThenBegin();
+    this.name = name;
+    this.tooltip = "The \"if\" statement evaluates an expression. If it's true, the specified statements are executed. Otherwise, they are skipped.";
+    if (expression.tooltip) {
+        this.tooltip += "<br><br><b>Expression:</b><br>" + expression.tooltip;
+    }
+    this.isBlocking = function(threadState, globalState) {
+        return (expression.isBlocking && expression.isBlocking(threadState, globalState));
+    };
+    this.execute = function(threadState, globalState, threadProgram) {
+        if (expression.evaluate(threadState, globalState)) {
+            moveToNextInstruction(threadState);  // goto true branch
+        } else {
+            // Condition is false, jump to matching EndIf.
+            var matchingEndIf = findMatchingInstructionIndex(threadProgram, name, EndIfInstruction);
+            goToInstruction(threadState, matchingEndIf);
+        }
+    };
 };
 
 var EndIfInstruction = function(name) {
-	this.code = "}";
-	this.tooltip = "This is the end of a simple \"if\" statement.";
-	this.name = name;
-	this.execute = function(threadState) {
-		moveToNextInstruction(threadState);
-	};
+    this.code = instructionCode(LanguageDependentEnd());
+    this.tooltip = "This is the end of a simple \"if\" statement.";
+    this.name = name;
+    this.execute = function(threadState) {
+        moveToNextInstruction(threadState);
+    };
 };
 
 var IfLongInstruction = function(expression, name) {
-	this.code = "<span class='keyword'>if</span> (" + expression.code + ") {";
-	this.name = name;
-	this.tooltip = "The \"if\" statement evaluates an expression. If it's true, the specified statements are executed. Otherwise, the \"else\" statements are executed.";
-	if (expression.tooltip) {
-		this.tooltip += "<br><br><b>Expression:</b><br>" + expression.tooltip;
-	}
-	this.isBlocking = function(threadState, globalState) {
-		return (expression.isBlocking && expression.isBlocking(threadState, globalState));
-	};
-	this.execute = function(threadState, globalState, threadProgram) {
-		if (expression.evaluate(threadState, globalState)) {
-			moveToNextInstruction(threadState);  // goto true branch
-		} else {
-			// false -> move 1 instruction after matching 'else'
-			var matchingElse = findMatchingInstructionIndex(threadProgram, name, ElseInstruction);
-			goToInstruction(threadState, matchingElse + 1);
-		}
-	};
+    this.code = LanguageDependentIf() + LanguageDependentIfWhileDoExpression(expression.code) + LanguageDependentThenBegin();
+    this.name = name;
+    this.tooltip = "The \"if\" statement evaluates an expression. If it's true, the specified statements are executed. Otherwise, the \"else\" statements are executed.";
+    if (expression.tooltip) {
+        this.tooltip += "<br><br><b>Expression:</b><br>" + expression.tooltip;
+    }
+    this.isBlocking = function(threadState, globalState) {
+        return (expression.isBlocking && expression.isBlocking(threadState, globalState));
+    };
+    this.execute = function(threadState, globalState, threadProgram) {
+        if (expression.evaluate(threadState, globalState)) {
+            moveToNextInstruction(threadState);  // goto true branch
+        } else {
+            // false -> move 1 instruction after matching 'else'
+            var matchingElse = findMatchingInstructionIndex(threadProgram, name, ElseInstruction);
+            goToInstruction(threadState, matchingElse + 1);
+        }
+    };
 };
 
 var ElseInstruction = function(name) {
-	this.code = "} <span class='keyword'>else</span> {";
-	this.name = name;
-	this.tooltip = "This is part of an \"if/else\" statement.";
-	this.execute = function(threadState, globalState, threadProgram) {
-		var matchingEndIfLong = findMatchingInstructionIndex(threadProgram, name, EndIfLongInstruction);
-		goToInstruction(threadState, matchingEndIfLong);
-	};
+    this.code = LanguageDependentEndElseBegin();
+    this.name = name;
+    this.tooltip = "This is part of an \"if/else\" statement.";
+    this.execute = function(threadState, globalState, threadProgram) {
+        var matchingEndIfLong = findMatchingInstructionIndex(threadProgram, name, EndIfLongInstruction);
+        goToInstruction(threadState, matchingEndIfLong);
+    };
 };
 
 var EndIfLongInstruction = function(name) {
-	this.code = "}";
-	this.tooltip = "This is the end of a complex \"if\" statement.";
-	this.name = name;
-	this.execute = function(threadState) {
-		moveToNextInstruction(threadState);
-	};
+    this.code = instructionCode(LanguageDependentEnd());
+    this.tooltip = "This is the end of a complex \"if\" statement.";
+    this.name = name;
+    this.execute = function(threadState) {
+        moveToNextInstruction(threadState);
+    };
 };
 
-
-var ExpandableInstruction = function(code, minorInstructions) {
-	this.code = code;
-	this.minorInstructions = minorInstructions;
-	this.tooltip = "This statement is not atomic and can be expanded into several minor statements that are atomic.";
-	this.execute = function(threadState, globalState, threadProgram) {
-		console.assert(!threadState.expanded);
-		threadState.expanded = true;
-		for (var i = 0; i < minorInstructions.length; i++) {
-			if (minorInstructions[i].isBlocking && minorInstructions[i].isBlocking(threadState, globalState)) {
-				// Cannot execute this subinstruction. Break.
-				break;
-			}
-			minorInstructions[i].execute(threadState, globalState, threadProgram);
-		}
-	};
+var ExpandableInstruction = function(expressionCode, minorInstructions) {
+    this.code = instructionCode(expressionCode);
+    this.minorInstructions = minorInstructions;
+    this.tooltip = "This statement is not atomic and can be expanded into several minor statements that are atomic.";
+    this.execute = function(threadState, globalState, threadProgram) {
+        console.assert(!threadState.expanded);
+        threadState.expanded = true;
+        for (var i = 0; i < minorInstructions.length; i++) {
+            if (minorInstructions[i].isBlocking && minorInstructions[i].isBlocking(threadState, globalState)) {
+                // Cannot execute this subinstruction. Break.
+                break;
+            }
+            minorInstructions[i].execute(threadState, globalState, threadProgram);
+        }
+    };
 };
+
+var AssignmentExpressionCode = function (left, right, separator) {
+    return BinaryOperatorCode(LanguageDependentIdentifierCapitalisation(left), LanguageDependentIdentifierCapitalisation(right), LanguageDependentAssignmentOperator(), separator);
+};
+
 var AtomicAssignmentToTemp = function (expression) {
-	this.code = "temp = " + expression.code + ";";
-	this.tooltip = "Evaluates the expression to the right and assigns it to the thread-local temporary variable on the left.";
-	this.execute = function(threadState, globalState) {
-		threadState.temporaryVariableValue = expression.evaluate(threadState, globalState);
-		moveToNextInstruction(threadState);
-	};
+    this.code = instructionCode(AssignmentExpressionCode("temp", expression.code));
+    this.tooltip = "Evaluates the expression to the right and assigns it to the thread-local temporary variable on the left.";
+    this.execute = function(threadState, globalState) {
+        threadState.temporaryVariableValue = expression.evaluate(threadState, globalState);
+        moveToNextInstruction(threadState);
+    };
 };
 var AtomicAssignmentFromTemp = function (name) {
-	this.code = name + " = temp;";
-	this.tooltip = "Moves the value from the thread-local temporary variable into the specified global variable.";
-	this.execute = function(threadState, globalState) {
-		globalState[name].value = threadState.temporaryVariableValue;
-		moveToNextInstruction(threadState);
-	};
+    this.code = instructionCode(AssignmentExpressionCode(name, "temp"));
+    this.tooltip = "Moves the value from the thread-local temporary variable into the specified global variable.";
+    this.execute = function(threadState, globalState) {
+        globalState[name].value = threadState.temporaryVariableValue;
+        moveToNextInstruction(threadState);
+    };
 };
 
 var createAssignment = function(name, expression) {
-	var minorInstructions = [
-		new AtomicAssignmentToTemp(expression),
-		new AtomicAssignmentFromTemp(name)
-	];
-	var v = new ExpandableInstruction(name + " = " + expression.code + ";", minorInstructions);
-	v.tooltip = "[Expandable] Assigns the value of the right-side expression to the variable on the left. This operation is non-atomic.";
-	return v;
+    var minorInstructions = [
+        new AtomicAssignmentToTemp(expression),
+        new AtomicAssignmentFromTemp(name)
+    ];
+    var v = new ExpandableInstruction(AssignmentExpressionCode(name, expression.code), minorInstructions);
+    v.tooltip = "[Expandable] Assigns the value of the right-side expression to the variable on the left. This operation is non-atomic.";
+    return v;
 };
 
 var createIncrement = function(name) {
-	var minorInstructions = [
-		new AtomicAssignmentToTemp(new AdditionExpression(new VariableExpression(name), new LiteralExpression(1))),
-		new AtomicAssignmentFromTemp(name)
-	];
-	var v = new ExpandableInstruction(name + "++;", minorInstructions);
-	v.tooltip = "[Expandable] Increments the value of the variable by one. This operation is non-atomic. However, the function Interlocked.Increment is atomic.";
-	return v;
+    var minorInstructions = [
+        new AtomicAssignmentToTemp(new AdditionExpression(new VariableExpression(name), new LiteralExpression(1))),
+        new AtomicAssignmentFromTemp(name)
+    ];
+    var v = new ExpandableInstruction(LanguageDependentIncrement(name), minorInstructions);
+    v.tooltip = "[Expandable] Increments the value of the variable by one. This operation is non-atomic. However, the function Interlocked.Increment is atomic.";
+    return v;
 };
 
 var EmptyStatement = function() {
-	this.code = ";";
-	this.tooltip = "This statement does nothing.";
-	this.execute = function(threadState, globalState) {
-		moveToNextInstruction(threadState);
-	};
+    this.code = ";";
+    this.tooltip = "This statement does nothing.";
+    this.execute = function(threadState, globalState) {
+        moveToNextInstruction(threadState);
+    };
 };
 
 var CommentInstruction = function(comment) {
-	this.code = "<span class='comment'>// " + comment + "</span>";
-	this.tooltip = "This is a comment. It does nothing.";
-	this.execute = function(threadState, globalState) {
-		moveToNextInstruction(threadState);
-	};
+    this.code = spanTag("comment", "// " + comment);
+    this.tooltip = "This is a comment. It does nothing.";
+    this.execute = function(threadState, globalState) {
+        moveToNextInstruction(threadState);
+    };
 };
 
-var WhileInstruction = function(expression, name, code) {
-	this.code = code ? code : ("<span class='keyword'>while</span> (" + expression.code + ") {");
-	this.name = name;
-	this.tooltip = "Executes the statements in the loop body until the specified condition ceases to be true.";
-	if (expression.tooltip) {
-		this.tooltip += "<br><br><b>Expression:</b><br>" + expression.tooltip;
-	}
-	this.execute = function(threadState, globalState, threadProgram) {
-		if (expression.evaluate(threadState, globalState)) {
-			moveToNextInstruction(threadState);
-		} else {
-			// false -> move 1 instruction after matching EndWhile
-			var matchingEndWhile = findMatchingInstructionIndex(threadProgram, name, EndWhileInstruction);
-			goToInstruction(threadState, matchingEndWhile + 1);
-		}
-	};
+var WhileInstruction = function(expression, name) {
+    this.code = (LanguageDependentWhile() + LanguageDependentIfWhileDoExpression(expression.code) + LanguageDependentDoBeginInWhileLoop());
+    this.name = name;
+    this.tooltip = "Executes the statements in the loop body until the specified condition ceases to be true.";
+    if (expression.tooltip) {
+        this.tooltip += "<br><br><b>Expression:</b><br>" + expression.tooltip;
+    }
+    this.execute = function(threadState, globalState, threadProgram) {
+        if (expression.evaluate(threadState, globalState)) {
+            moveToNextInstruction(threadState);
+        } else {
+            // false -> move 1 instruction after matching EndWhile
+            var matchingEndWhile = findMatchingInstructionIndex(threadProgram, name, EndWhileInstruction);
+            goToInstruction(threadState, matchingEndWhile + 1);
+        }
+    };
 };
 
 var createOuterWhile = function() {
-	return new WhileInstruction(new LiteralExpression(true), "__outerWhile");
+    return new WhileInstruction(new LiteralExpression(true), "__outerWhile");
 };
 var createOuterWhileEnd = function() {
-	return new EndWhileInstruction("__outerWhile");
+    return new EndWhileInstruction("__outerWhile");
 };
 
 var EndWhileInstruction = function( name) {
-	this.code = "}";
-	this.tooltip = "Marks the end of a while loop.";
-	this.name = name;
-	this.execute = function(threadState, globalState, threadProgram) {
-		// Jump back to start of matching 'while'.
-		var matchingWhile = findMatchingInstructionIndex(threadProgram, name, WhileInstruction);
-		goToInstruction(threadState, matchingWhile);
-	};
+    this.code = instructionCode(LanguageDependentEnd());
+    this.tooltip = "Marks the end of a while loop.";
+    this.name = name;
+    this.execute = function(threadState, globalState, threadProgram) {
+        // Jump back to start of matching 'while'.
+        var matchingWhile = findMatchingInstructionIndex(threadProgram, name, WhileInstruction);
+        goToInstruction(threadState, matchingWhile);
+    };
 };

--- a/js/language.js
+++ b/js/language.js
@@ -1,0 +1,158 @@
+// language dependent things: try to abstract as much of language specifics here
+
+var BinaryOperatorCode = function(left, right, operator, separator) {
+    // TODO: find a better way than separator to split large expressions
+    var separator;
+    if (!separator) {
+        separator = " "
+    }
+    return left + " " + operator + separator + right;
+};
+
+var keywordCode = function(keyword) {
+    return spanTag("keyword", keyword);
+};
+
+function snakeCaseToCamelCase(string){
+    return string.replace(/\_\w/g, // convert underscore followed by word-characters through the function
+        function(match) {
+            return match.charAt(1).toUpperCase(); // match[0] is the underscore
+        }
+    );
+}
+
+var capitaliseFirstLetter = function(string) {
+    return string.charAt(0).toUpperCase() + string.slice(1);
+}
+
+function snakeCaseToPascalCase(s) {
+    return capitaliseFirstLetter(snakeCaseToCamelCase(s));
+}
+
+var ParenthesisedExpressionCode = function(expressionCode) {
+    return "(" + expressionCode + ")";
+};
+
+var LanguageDependentIdentifierCapitalisation = function(identifier) {
+    return identifier; // C#
+}
+
+var LanguageDependentRefParameter = function(parameterName) {
+    return keywordCode("ref") + " " + parameterName; // C#
+}
+
+var LanguageDependentIntegerDivisionOperator = function () {
+    return "/"; // C#
+}
+
+var LanguageDependentIntegerModulusOperator = function () {
+    return "%"; // C#
+}
+
+var LanguageDependentAssignmentOperator = function () {
+    return "="; // C#
+}
+
+var LanguageDependentBooleanAndOperator = function () {
+    return "&&"; // C#
+}
+
+var LanguageDependentBooleanOrOperator = function () {
+    return "||"; // C#
+}
+
+var LanguageDependentValueEqualityOperator = function () {
+    return "=="; // C#
+}
+
+var LanguageDependentValueInequalityOperator = function () {
+    return "!="; // C#
+}
+
+var LanguageDependentClassName = function(className) {
+    return className; // C#
+}
+
+var LanguageDependentInterfaceName = function(className) {
+    return "I" + LanguageDependentIdentifierCapitalisation(className); // C# or Delphi
+}
+
+var LanguageDependentConstruction = function(className) {
+    return keywordCode("new") + " " + className + "()"; // C#
+}
+
+var LanguageDependentBegin = function() {
+    return "{"; // C#
+}
+
+var LanguageDependentDo = function() {
+    return keywordCode("do"); // C# or Delphi
+}
+
+var LanguageDependentDoBegin = function() {
+    return LanguageDependentDo() + " " + LanguageDependentBegin(); // Delphi or C#
+}
+
+var LanguageDependentDoBeginInWhileLoop = function() {
+    return LanguageDependentDo(); // C#
+}
+
+var LanguageDependentElse = function() {
+    return keywordCode("else"); // C# or Delphi
+}
+var LanguageDependentEnd = function() {
+    return "}"; // C#
+}
+
+var LanguageDependentEndElseBegin = function() {
+    return LanguageDependentEnd() + " " + LanguageDependentElse() + " " + LanguageDependentBegin(); // C# or Delphi
+}
+
+var LanguageDependentIf = function() {
+    return keywordCode("if"); // C# or Delphi
+}
+
+var LanguageDependentIfWhileDoExpression = function(expressionCode) {
+    var resultExpression = ParenthesisedExpressionCode(expressionCode); // C#
+    return " " + resultExpression + " ";
+};
+
+var LanguageDependentIncrement = function(name) {
+    var capitalisedName = LanguageDependentIdentifierCapitalisation(name);
+    return capitalisedName + "++"; // C#
+}
+
+var LanguageDependentInterlockedIncrement = function(name) {
+    var capitalised = LanguageDependentRefParameter(name);
+    return staticMethodExpressionCode("Interlocked", "Increment", capitalised); // C#
+}
+
+var LanguageDependentThen = function() {
+    return keywordCode("then"); // Delphi
+}
+
+var LanguageDependentThenBegin = function() {
+    return LanguageDependentBegin(); // C#
+}
+
+var LanguageDependentWhile = function() {
+    return keywordCode("while"); // C# or Delphi
+}
+
+var LanguageDependentLiteralExpression = function(value) {
+    if ((value === false) || (value === true)) {
+        var capitalised = LanguageDependentIdentifierCapitalisation(value.toString());
+        return keywordCode(capitalised); // C#
+    } else {
+        return value.toString();
+    }
+};
+
+var LanguageDependentDebugInstanceName = function() {
+    return debugInstanceName = "Debug"; // C#
+}
+
+var LanguageDependentAndOperatorCode = function(left, right, separator) {
+    // because of Delphi operator precedence: `and` has less precedence than comparison operators
+    return BinaryOperatorCode(left, right, LanguageDependentBooleanAndOperator(), separator); // C#
+};

--- a/js/ui.js
+++ b/js/ui.js
@@ -40,8 +40,8 @@ var updateGlobalVariables = function() {
         var variableString = ToString(variable);
         var variableValue = variable.value;
         var representation = $('<div class="variable"></div>');
-        representation.append($('<a href="https://msdn.microsoft.com/en-us/library/' + type.relativeUrl + '" class="type"></a>').text(type.name));
-        representation.append($('<span class="name"></span>').text(variable.name));
+        representation.append($('<a href="https://msdn.microsoft.com/en-us/library/' + type.relativeUrl + '" class="type"></a>').text(type.displayName));
+        representation.append($('<span class="name"></span>').text(variable.displayName));
 
         if (variableValue == "unimportant") {
             // intentionally left blank
@@ -52,23 +52,28 @@ var updateGlobalVariables = function() {
             }
         } else {
             representation.append($('<span class="equalSign"></span>').text('='));
-
-            var valueRepr;
             var typeName = type.name;
-            if (typeName == "System.String") {
-                valueRepr = '"' + variableValue + '"';
-            }
-            else if (typeName.indexOf("Semaphore") != -1) {
-                valueRepr = 'SemaphoreSlim [count: ' + variableValue + ']';
-            }
-            else if (typeName.indexOf("Queue") != -1) {
-                valueRepr = 'Queue [element count: ' + variableValue + ']';
-            }
-            else {
-                valueRepr = variableValue.toString();
-            }
 
-            representation.append($('<span class="value"></span>').text(valueRepr));
+            if (typeName == "System.Boolean") {
+                var booleanExpression = new LiteralExpression(variableValue);
+                representation.append(booleanExpression.code); // it already has the 'span class="keyword"'
+            } else {
+                var valueRepr;
+                if (typeName == "System.String") {
+                    valueRepr = '"' + variableValue + '"';
+                }
+                else if (typeName.indexOf("Semaphore") != -1) {
+                    valueRepr = 'SemaphoreSlim [count: ' + variableValue + ']';
+                }
+                else if (typeName.indexOf("Queue") != -1) {
+                    valueRepr = 'Queue [element count: ' + variableValue + ']';
+                }
+                else {
+                    valueRepr = variableValue.toString();
+                }
+
+                representation.append($('<span class="value"></span>').text(valueRepr));
+            }
         }
 
         representation.append(";");
@@ -147,7 +152,7 @@ var updateMSDNLinks = function() {
                 $(this).attr('target', '_blank');
             }
         }
-    if (!$(this).hasClass("wikipedia-link")) {
+        if (!$(this).hasClass("wikipedia-link")) {
             if (this.href.indexOf("en.wikipedia.org") !== -1) {
                 $(this).addClass("wikipedia-link");
                 $(this).attr('target', '_blank');

--- a/js/ui.js
+++ b/js/ui.js
@@ -5,146 +5,155 @@ function showMessage(caption, text) {
 }
 
 var updateProgramCounters = function() {
-	$('.instruction').each(function() {
-		$(this).removeClass('current-instruction');
-	});
-	$('.expansion').each(function() {
-		$(this).css({display: "none"});
-	});
-	// update program counters
-	for (var i = 0; i < gameState.getThreadCount(); i++) {
-		var threadState = gameState.threadState[i];
-		var pc = threadState.programCounter[0];
-		var program = gameState.getProgramOfThread(i);
+    $('.instruction').each(function() {
+        $(this).removeClass('current-instruction');
+    });
+    $('.expansion').each(function() {
+        $(this).css({display: "none"});
+    });
+    // update program counters
+    for (var i = 0; i < gameState.getThreadCount(); i++) {
+        var threadState = gameState.threadState[i];
+        var pc = threadState.programCounter[0];
+        var program = gameState.getProgramOfThread(i);
 
-		if (pc < program.length) {
-			$('#instruction-' + i + '-' + pc).addClass('current-instruction');
-		}
+        if (pc < program.length) {
+            $('#instruction-' + i + '-' + pc).addClass('current-instruction');
+        }
 
-		if (program[pc] instanceof ExpandableInstruction) {
-			$('#instruction-' + i + '-' + pc + '-expansion').css({display: (threadState.expanded ? 'block' : 'none')});
+        if (program[pc] instanceof ExpandableInstruction) {
+            $('#instruction-' + i + '-' + pc + '-expansion').css({display: (threadState.expanded ? 'block' : 'none')});
 
-			if (threadState.expanded) {
-				$('#instruction-' + i + '-' + pc + '-sub' + threadState.programCounter[1]).addClass('current-instruction');
-			}
-		}
-	}
+            if (threadState.expanded) {
+                $('#instruction-' + i + '-' + pc + '-sub' + threadState.programCounter[1]).addClass('current-instruction');
+            }
+        }
+    }
 };
 
 var updateGlobalVariables = function() {
-	var area = $('.global-state');
-	area.html("<hr>");
-	for (var key in gameState.globalState) {
-		var variable = gameState.globalState[key];
-		var representation = $('<div class="variable"></div>');
-		representation.append($('<a href="https://msdn.microsoft.com/en-us/library/' + variable.relativeUrl + '" class="type"></a>').text(variable.type));
-		representation.append($('<span class="name"></span>').text(variable.name));
-		if (variable.value == "unimportant") {
+    var area = $('.global-state');
+    area.html("<hr>");
+    for (var key in gameState.globalState) {
+        var variable = gameState.globalState[key];
+        var type = variable.type;
+        var variableString = ToString(variable);
+        var variableValue = variable.value;
+        var representation = $('<div class="variable"></div>');
+        representation.append($('<a href="https://msdn.microsoft.com/en-us/library/' + type.relativeUrl + '" class="type"></a>').text(type.name));
+        representation.append($('<span class="name"></span>').text(variable.name));
 
-		} else if (ToString(variable) != null) {
-			representation.append($('<span class="value"></span>').text(" " + ToString(variable)));
-		} else {
-			representation.append($('<span class="equalSign"></span>').text('='));
+        if (variableValue == "unimportant") {
+            // intentionally left blank
+        } else if (variableString != null) {
+            if (variableString != "") {
+                representation.append(" ");
+                representation.append($('<span class="value"></span>').text(variableString));
+            }
+        } else {
+            representation.append($('<span class="equalSign"></span>').text('='));
 
-			var valueRepr;
-			if (variable.type == "String") {
-				valueRepr = '"' + variable.value + '"';
-			}
-			else if (variable.type.indexOf("Semaphore") != -1) {
-				valueRepr = 'SemaphoreSlim [count: ' + variable.value + ']';
-			}
-			else if (variable.type.indexOf("Queue") != -1) {
-				valueRepr = 'Queue [element count: ' + variable.value + ']';
-			}
-			else {
-				valueRepr = variable.value.toString();
-			}
+            var valueRepr;
+            var typeName = type.name;
+            if (typeName == "System.String") {
+                valueRepr = '"' + variableValue + '"';
+            }
+            else if (typeName.indexOf("Semaphore") != -1) {
+                valueRepr = 'SemaphoreSlim [count: ' + variableValue + ']';
+            }
+            else if (typeName.indexOf("Queue") != -1) {
+                valueRepr = 'Queue [element count: ' + variableValue + ']';
+            }
+            else {
+                valueRepr = variableValue.toString();
+            }
 
-			representation.append($('<span class="value"></span>').text(valueRepr));
-		}
+            representation.append($('<span class="value"></span>').text(valueRepr));
+        }
 
-		representation.append(";");
-		if (variable.lastLockedByThread != null) {
-			if (variable.lockCount == 1) {
-				representation.append(" (locked by thread " + variable.lastLockedByThread + ")");
-			} else {
-				representation.append(" (locked by thread " + variable.lastLockedByThread + ", " + variable.lockCount + " times)");
-			}
-		}
-		area.append(representation);
-	}
+        representation.append(";");
+        if (variable.lastLockedByThread != null) {
+            if (variable.lockCount == 1) {
+                representation.append(" (locked by thread " + variable.lastLockedByThread + ")");
+            } else {
+                representation.append(" (locked by thread " + variable.lastLockedByThread + ", " + variable.lockCount + " times)");
+            }
+        }
 
-	updateMSDNLinks();
+        area.append(representation);
+    }
+
+    updateMSDNLinks();
 };
 
 var redraw = function() {
-	updateProgramCounters();
-	updateGlobalVariables();
+    updateProgramCounters();
+    updateGlobalVariables();
 
-	var undoEnabled = (undoHistory.length > 0);
-	undoButton.attr('disabled', !undoEnabled);
-	undoButton.removeClass('btn-info');
-	undoButton.removeClass('btn-default');
-	undoButton.addClass(undoEnabled ? 'btn-info' : 'btn-default');
+    var undoEnabled = (undoHistory.length > 0);
+    undoButton.attr('disabled', !undoEnabled);
+    undoButton.removeClass('btn-info');
+    undoButton.removeClass('btn-default');
+    undoButton.addClass(undoEnabled ? 'btn-info' : 'btn-default');
 
-	if (levelWasCleared) {
-		nextChallengeButton.show();
-		wonBanner.show();
-	} else {
-		nextChallengeButton.hide();
-		wonBanner.hide();
-	}
+    if (levelWasCleared) {
+        nextChallengeButton.show();
+        wonBanner.show();
+    } else {
+        nextChallengeButton.hide();
+        wonBanner.hide();
+    }
 
-	for (var i = 0; i < gameState.getThreadCount(); i++) {
-		var program = gameState.getProgramOfThread(i);
-		var threadState = gameState.threadState[i];
-		var currentInstruction = program[threadState.programCounter[0]];
+    for (var i = 0; i < gameState.getThreadCount(); i++) {
+        var program = gameState.getProgramOfThread(i);
+        var threadState = gameState.threadState[i];
+        var currentInstruction = program[threadState.programCounter[0]];
 
-		var buttons = threadButtons[i];
-		var stepButton = buttons.step;
-		if (isThreadFinished(i)) {
-			stepButton.attr('disabled', true);
-			stepButton.attr('title', 'This thread is finished.');
-			stepButton.tooltip();
-			buttons.blockReason.html('');
-		} else if (isThreadBlocked(i)) {
-			stepButton.attr('disabled', true);
-			stepButton.attr('title', 'This thread is blocked.');
-			stepButton.tooltip();
+        var buttons = threadButtons[i];
+        var stepButton = buttons.step;
+        if (isThreadFinished(i)) {
+            stepButton.attr('disabled', true);
+            stepButton.attr('title', 'This thread is finished.');
+            stepButton.tooltip();
+            buttons.blockReason.html('');
+        } else if (isThreadBlocked(i)) {
+            stepButton.attr('disabled', true);
+            stepButton.attr('title', 'This thread is blocked.');
+            stepButton.tooltip();
 
-			var reason = isThreadBlocked(i);
-			if (reason === true) {
-				// (Default filler.)
-				reason = "This thread is blocked.";
-			}
-			buttons.blockReason.html('<span class="glyphicon glyphicon-time"></span>&nbsp;' + reason);
-		} else {
-			stepButton.attr('disabled', false);
-			stepButton.attr('title', '');
-			stepButton.tooltip('destroy');
-			buttons.blockReason.html('');
-		}
+            var reason = isThreadBlocked(i);
+            if (reason === true) {
+                // (Default filler.)
+                reason = "This thread is blocked.";
+            }
+            buttons.blockReason.html('<span class="glyphicon glyphicon-time"></span>&nbsp;' + reason);
+        } else {
+            stepButton.attr('disabled', false);
+            stepButton.attr('title', '');
+            stepButton.tooltip('destroy');
+            buttons.blockReason.html('');
+        }
 
-		var isExpandable = (currentInstruction instanceof ExpandableInstruction);
-		buttons.expand.attr('disabled', !(isExpandable && !threadState.expanded));
-	}
+        var isExpandable = (currentInstruction instanceof ExpandableInstruction);
+        buttons.expand.attr('disabled', !(isExpandable && !threadState.expanded));
+    }
 };
 
 var updateMSDNLinks = function() {
-	$('a').each(function(i) {
-		if (!$(this).hasClass("msdn-link")) {
-			if (this.href.indexOf("msdn.microsoft.com") !== -1) {
-				$(this).addClass("msdn-link");
-				$(this).attr('target', '_blank');
-			}
-		}
+    $('a').each(function(i) {
+        if (!$(this).hasClass("msdn-link")) {
+            if (this.href.indexOf("msdn.microsoft.com") !== -1) {
+                $(this).addClass("msdn-link");
+                $(this).attr('target', '_blank');
+            }
+        }
     if (!$(this).hasClass("wikipedia-link")) {
-			if (this.href.indexOf("en.wikipedia.org") !== -1) {
-				$(this).addClass("wikipedia-link");
-				$(this).attr('target', '_blank');
-			}
-		}
-	});
+            if (this.href.indexOf("en.wikipedia.org") !== -1) {
+                $(this).addClass("wikipedia-link");
+                $(this).attr('target', '_blank');
+            }
+        }
+    });
 };
 
 $(updateMSDNLinks);

--- a/js/ui.js
+++ b/js/ui.js
@@ -37,7 +37,7 @@ var updateGlobalVariables = function() {
 	for (var key in gameState.globalState) {
 		var variable = gameState.globalState[key];
 		var representation = $('<div class="variable"></div>');
-		representation.append($('<a href="https://msdn.microsoft.com/en-us/library/' + variable.type + '" class="type"></a>').text(variable.type));
+		representation.append($('<a href="https://msdn.microsoft.com/en-us/library/' + variable.relativeUrl + '" class="type"></a>').text(variable.type));
 		representation.append($('<span class="name"></span>').text(variable.name));
 		if (variable.value == "unimportant") {
 
@@ -135,6 +135,12 @@ var updateMSDNLinks = function() {
 		if (!$(this).hasClass("msdn-link")) {
 			if (this.href.indexOf("msdn.microsoft.com") !== -1) {
 				$(this).addClass("msdn-link");
+				$(this).attr('target', '_blank');
+			}
+		}
+    if (!$(this).hasClass("wikipedia-link")) {
+			if (this.href.indexOf("en.wikipedia.org") !== -1) {
+				$(this).addClass("wikipedia-link");
 				$(this).attr('target', '_blank');
 			}
 		}

--- a/js/variables.js
+++ b/js/variables.js
@@ -1,62 +1,107 @@
+var BooleanType = function() {
+    this.name = "System.Boolean";
+    this.displayName = "bool";
+    this.relativeUrl = this.name;
+};
 var BooleanVariable = function (name, defaultValue) {
     this.name = name;
-    this.relativeUrl = "System.Boolean";
-    this.type = this.relativeUrl;
+    this.type = new BooleanType();
     this.value = defaultValue;
+};
+
+var IntegerType = function() {
+    this.name = "System.Int32";
+    this.displayName = "int";
+    this.relativeUrl = this.name;
 };
 var IntegerVariable = function (name, defaultValue) {
     this.name = name;
-    this.relativeUrl = "System.Int32";
-    this.type = this.relativeUrl;
+    this.type = new IntegerType();
     this.value = defaultValue;
+};
+
+var CountdownEventType = function() {
+    this.name = "System.Threading.CountdownEvent";
+    this.displayName = this.name;
+    this.relativeUrl = this.name;
 };
 var CountdownEventVariable = function (name, count) {
     this.name = name;
-    this.relativeUrl = "System.Threading.CountdownEvent";
-    this.type = this.relativeUrl;
+    this.type = new CountdownEventType();
     this.value = count;
+};
+
+var ManualResetEventType = function() {
+    this.name = "System.Threading.ManualResetEventSlim";
+    this.displayName = this.name;
+    this.relativeUrl = this.name;
 };
 var ManualResetEventVariable = function (name, value) {
     this.name = name;
-    this.relativeUrl = "System.Threading.ManualResetEventSlim";
-    this.type = this.relativeUrl;
+    this.type = new ManualResetEventType();
     this.value = value;
+};
+
+var BarrierVariableType = function() {
+    this.name = "System.Threading.Barrier";
+    this.displayName = this.name;
+    this.relativeUrl = this.name;
 };
 var BarrierVariable = function (name, participantCount) {
     this.name = name;
-    this.relativeUrl = "System.Threading.Barrier";
-    this.type = this.relativeUrl;
+    this.type = new BarrierVariableType();
     this.value = participantCount;
     this.numberOfParticipants = participantCount;
     this.hasArrived = [];
     this.phase = 0;
 };
+
+var SemaphoreType = function() {
+    this.name = "System.Threading.SemaphoreSlim";
+    this.displayName = this.name;
+    this.relativeUrl = this.name;
+};
 var SemaphoreVariable = function(name, value) {
     this.name = name;
-    this.relativeUrl = "System.Threading.SemaphoreSlim";
-    this.type = this.relativeUrl;
+    this.type = new SemaphoreType();
     this.value = value;
+};
+
+var QueueType = function(innerType) {
+    this.name = "System.Collections.Generic.Queue" + "<" + innerType.name + ">";
+    this.displayName = "System.Collections.Generic.Queue" + "<" + innerType.displayName + ">";
+    this.relativeUrl = "7977ey2c";
 };
 var QueueVariable = function(name, innerType, value) {
     this.name = name;
-    this.relativeUrl = "7977ey2c";
-    this.type = "System.Collections.Generic.Queue" + "<" + innerType + ">";
+    this.type = new QueueType(innerType);
     this.value = value;
 };
+
+var ObjectType = function(name) {
+    this.name = "System.Object";
+    this.relativeUrl = this.name;
+    if (name != null) {
+        this.name = name;
+        this.displayName = name;
+    } else {
+        this.displayName = "object";
+    }
+}
 var ObjectVariable = function(name) {
     this.name = name;
-    this.relativeUrl = "System.Object";
-    this.type = this.relativeUrl;
+    this.type = new ObjectType();
 };
+
 /**
  * Returns the variable value in human-readable form.
  * @param variable A variable.
  * @returns string Its value in human form.
  */
 var ToString = function(variable) {
-    var type = variable.type;
+    var typeName = variable.type.name;
     var value = variable.value;
-    switch (type) {
+    switch (typeName) {
         case "System.Threading.CountdownEvent":
             return value == 0 ? "[event set]" : (value == 1 ? "[waits for one more signal]" : "[waits for " + value + " more signals]");
         case "System.Threading.ManualResetEventSlim":
@@ -69,7 +114,7 @@ var ToString = function(variable) {
             return "[counter: " + value + "]";
 
     }
-    if (type.indexOf("System.Collections.Generic.Queue") == 0) {
+    if (typeName.indexOf("System.Collections.Generic.Queue") == 0) {
         return "[number of enqueued items: " + value + "]";
     }
     return null;

--- a/js/variables.js
+++ b/js/variables.js
@@ -27,19 +27,19 @@ var BarrierVariable = function (name, participantCount) {
 };
 var SemaphoreVariable = function(name, value) {
     this.name = name;
-    this.relativeUrl = 'System.Threading.SemaphoreSlim';
+    this.relativeUrl = "System.Threading.SemaphoreSlim";
     this.type = this.relativeUrl;
     this.value = value;
 };
 var QueueVariable = function(name, innerType, value) {
     this.name = name;
-    this.relativeUrl = 'System.Collections.Generic.Queue';
-    this.type = this.relativeUrl + '<' + innerType + '>';
+    this.relativeUrl = "7977ey2c";
+    this.type = "System.Collections.Generic.Queue" + "<" + innerType + ">";
     this.value = value;
 };
 var ObjectVariable = function(name) {
     this.name = name;
-    this.relativeUrl = 'System.Object';
+    this.relativeUrl = "System.Object";
     this.type = this.relativeUrl;
 };
 /**
@@ -63,7 +63,7 @@ var ToString = function(variable) {
             return "[counter: " + value + "]";
 
     }
-    if (type.indexOf('System.Collections.Generic.Queue') == 0) {
+    if (type.indexOf("System.Collections.Generic.Queue") == 0) {
         return "[number of enqueued items: " + value + "]";
     }
     return null;

--- a/js/variables.js
+++ b/js/variables.js
@@ -1,21 +1,25 @@
 var IntegerVariable = function (name, defaultValue) {
     this.name = name;
-    this.type = "System.Int32";
+    this.relativeUrl = "System.Int32";
+    this.type = this.relativeUrl;
     this.value = defaultValue;
 };
 var CountdownEventVariable = function (name, count) {
     this.name = name;
-    this.type = "System.Threading.CountdownEvent";
+    this.relativeUrl = "System.Threading.CountdownEvent";
+    this.type = this.relativeUrl;
     this.value = count;
 };
 var ManualResetEventVariable = function (name, value) {
     this.name = name;
-    this.type = "System.Threading.ManualResetEventSlim";
+    this.relativeUrl = "System.Threading.ManualResetEventSlim";
+    this.type = this.relativeUrl;
     this.value = value;
 };
 var BarrierVariable = function (name, participantCount) {
     this.name = name;
-    this.type = "System.Threading.Barrier";
+    this.relativeUrl = "System.Threading.Barrier";
+    this.type = this.relativeUrl;
     this.value = participantCount;
     this.numberOfParticipants = participantCount;
     this.hasArrived = [];
@@ -23,17 +27,20 @@ var BarrierVariable = function (name, participantCount) {
 };
 var SemaphoreVariable = function(name, value) {
     this.name = name;
-    this.type = 'System.Threading.SemaphoreSlim';
+    this.relativeUrl = 'System.Threading.SemaphoreSlim';
+    this.type = this.relativeUrl;
     this.value = value;
 };
 var QueueVariable = function(name, innerType, value) {
     this.name = name;
-    this.type = 'System.Collections.Generic.Queue<' + innerType + '>';
+    this.relativeUrl = 'System.Collections.Generic.Queue';
+    this.type = this.relativeUrl + '<' + innerType + '>';
     this.value = value;
 };
 var ObjectVariable = function(name) {
     this.name = name;
-    this.type = 'System.Object';
+    this.relativeUrl = 'System.Object';
+    this.type = this.relativeUrl;
 };
 /**
  * Returns the variable value in human-readable form.

--- a/js/variables.js
+++ b/js/variables.js
@@ -1,3 +1,9 @@
+var BooleanVariable = function (name, defaultValue) {
+    this.name = name;
+    this.relativeUrl = "System.Boolean";
+    this.type = this.relativeUrl;
+    this.value = defaultValue;
+};
 var IntegerVariable = function (name, defaultValue) {
     this.name = name;
     this.relativeUrl = "System.Int32";

--- a/js/variables.js
+++ b/js/variables.js
@@ -5,6 +5,7 @@ var BooleanType = function() {
 };
 var BooleanVariable = function (name, defaultValue) {
     this.name = name;
+    this.displayName = LanguageDependentIdentifierCapitalisation(name);
     this.type = new BooleanType();
     this.value = defaultValue;
 };
@@ -16,6 +17,7 @@ var IntegerType = function() {
 };
 var IntegerVariable = function (name, defaultValue) {
     this.name = name;
+    this.displayName = LanguageDependentIdentifierCapitalisation(name);
     this.type = new IntegerType();
     this.value = defaultValue;
 };
@@ -27,6 +29,7 @@ var CountdownEventType = function() {
 };
 var CountdownEventVariable = function (name, count) {
     this.name = name;
+    this.displayName = LanguageDependentIdentifierCapitalisation(name);
     this.type = new CountdownEventType();
     this.value = count;
 };
@@ -38,6 +41,7 @@ var ManualResetEventType = function() {
 };
 var ManualResetEventVariable = function (name, value) {
     this.name = name;
+    this.displayName = LanguageDependentIdentifierCapitalisation(name);
     this.type = new ManualResetEventType();
     this.value = value;
 };
@@ -49,6 +53,7 @@ var BarrierVariableType = function() {
 };
 var BarrierVariable = function (name, participantCount) {
     this.name = name;
+    this.displayName = LanguageDependentIdentifierCapitalisation(name);
     this.type = new BarrierVariableType();
     this.value = participantCount;
     this.numberOfParticipants = participantCount;
@@ -63,6 +68,7 @@ var SemaphoreType = function() {
 };
 var SemaphoreVariable = function(name, value) {
     this.name = name;
+    this.displayName = LanguageDependentIdentifierCapitalisation(name);
     this.type = new SemaphoreType();
     this.value = value;
 };
@@ -74,6 +80,7 @@ var QueueType = function(innerType) {
 };
 var QueueVariable = function(name, innerType, value) {
     this.name = name;
+    this.displayName = LanguageDependentIdentifierCapitalisation(name);
     this.type = new QueueType(innerType);
     this.value = value;
 };
@@ -83,13 +90,14 @@ var ObjectType = function(name) {
     this.relativeUrl = this.name;
     if (name != null) {
         this.name = name;
-        this.displayName = name;
+        this.displayName = LanguageDependentClassName(name);
     } else {
         this.displayName = "object";
     }
 }
 var ObjectVariable = function(name) {
     this.name = name;
+    this.displayName = LanguageDependentIdentifierCapitalisation(name);
     this.type = new ObjectType();
 };
 


### PR DESCRIPTION
See #50 

The pull-request fixes these:

- `System.Collections.Generic.Queue` hyperlinks don't work as they contain the inner type
- non-MSDN hyperlinks open in the same window as they miss `target='_blank'`
- "Peterson Algorithm" -> "Peterson's Algorithm" and hyperlink

Sorry for the tab->space conversion in one of the files. No offence, but most files were already space indented anyway and my dev-toolchain is completely space based so that was easier for me.